### PR TITLE
Added a due date check for quarterly or monthly

### DIFF
--- a/src/components/forms/ConfirmationPage.jsx
+++ b/src/components/forms/ConfirmationPage.jsx
@@ -59,24 +59,15 @@ const ConfirmationForm = props => {
         );
       }
 
-      let dueDate = "";
-      if (ReturnType === 1) {
-        dueDate = GetFormattedDueDate(
-          new Date(
-            response.MonthlyData[2].Month +
-              "/01/" +
-              response.MonthlyData[2].Year
-          )
-        );
-      } else {
-        dueDate = GetFormattedDueDate(
-          new Date(
-            response.MonthlyData[0].Month +
-              "/01/" +
-              response.MonthlyData[0].Year
-          )
-        );
-      }
+      const monthOfReturn = ReturnType === 1 ? 2 : 0;
+
+      const dueDate = GetFormattedDueDate(
+        new Date(
+          response.MonthlyData[monthOfReturn].Month +
+            "/01/" +
+            response.MonthlyData[monthOfReturn].Year
+        )
+      );
 
       formattedResponse.monthlyOccupancy = monthlyOccupancy;
       formattedResponse.monthlyExemption = monthlyExemption;

--- a/src/components/forms/ConfirmationPage.jsx
+++ b/src/components/forms/ConfirmationPage.jsx
@@ -63,9 +63,9 @@ const ConfirmationForm = props => {
 
       const dueDate = GetFormattedDueDate(
         new Date(
-          response.MonthlyData[monthOfReturn].Month +
+          MonthlyData[monthOfReturn].Month +
             "/01/" +
-            response.MonthlyData[monthOfReturn].Year
+            MonthlyData[monthOfReturn].Year
         )
       );
 

--- a/src/components/forms/ConfirmationPage.jsx
+++ b/src/components/forms/ConfirmationPage.jsx
@@ -17,7 +17,8 @@ const ConfirmationForm = props => {
     monthlyExemption,
     monthlyPenalty,
     totalRemittedTax,
-    monthSubmitted
+    monthSubmitted,
+    dueDate
   } = response;
 
   const datetimeFormat = "MMMM yyyy h:mm aaa";
@@ -25,7 +26,7 @@ const ConfirmationForm = props => {
 
   useEffect(() => {
     const mapResponse = response => {
-      const { DateSubmitted, MonthlyData } = response;
+      const { DateSubmitted, MonthlyData, ReturnType } = response;
       const formattedResponse = { ...response };
       formattedResponse.DateSubmitted = GetFormatedDateTime(
         new Date(DateSubmitted),
@@ -58,11 +59,31 @@ const ConfirmationForm = props => {
         );
       }
 
+      let dueDate = "";
+      if (ReturnType === 1) {
+        dueDate = GetFormattedDueDate(
+          new Date(
+            response.MonthlyData[2].Month +
+              "/01/" +
+              response.MonthlyData[2].Year
+          )
+        );
+      } else {
+        dueDate = GetFormattedDueDate(
+          new Date(
+            response.MonthlyData[0].Month +
+              "/01/" +
+              response.MonthlyData[0].Year
+          )
+        );
+      }
+
       formattedResponse.monthlyOccupancy = monthlyOccupancy;
       formattedResponse.monthlyExemption = monthlyExemption;
       formattedResponse.monthlyPenalty = monthlyPenalty;
       formattedResponse.totalRemittedTax = "$" + totalRemittedTax;
       formattedResponse.monthSubmitted = monthSubmitted;
+      formattedResponse.dueDate = dueDate;
 
       return formattedResponse;
     };
@@ -73,7 +94,7 @@ const ConfirmationForm = props => {
   }, [confirmationNumber]);
 
   const date = new Date();
-  const dueDate = GetFormattedDueDate(date);
+
   const newDueDate = GetFormattedDueDate(
     date.setMonth(date.getMonth() + 1)
   ).toString();


### PR DESCRIPTION
Corrected due date to address #82 

Originally it was taking the current date and assuming that was the date submitted. It will now look to see the type of return (monthly or quarterly) then calculate the due date based on the return type.