### PR TITLE
Disable months quarterly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2468,7 +2468,8 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
@@ -2490,6 +2491,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2759,12 +2761,14 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -4512,7 +4516,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -4549,7 +4554,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -4558,7 +4564,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4661,7 +4668,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4671,6 +4679,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4683,17 +4692,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4710,6 +4722,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4782,7 +4795,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4792,6 +4806,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4867,7 +4882,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -4897,6 +4913,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4914,6 +4931,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -4952,11 +4970,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -8005,12 +8025,14 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -9444,7 +9466,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9481,7 +9504,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -9490,7 +9514,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9593,7 +9618,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9603,6 +9629,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9622,11 +9649,13 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9643,6 +9672,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9715,7 +9745,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9725,6 +9756,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9800,7 +9832,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9830,6 +9863,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9847,6 +9881,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9885,11 +9920,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -12043,7 +12080,8 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",

--- a/src/components/ReturnDateSelector.jsx
+++ b/src/components/ReturnDateSelector.jsx
@@ -79,7 +79,8 @@ const ReturnInterval = props => {
 
   const getMonth = monthIndex => {
     if (Object.entries(months).length > 0) {
-      return GetFormatedDateTime(new Date(months[monthIndex]), "MM/yyyy");
+      const month = months[monthIndex];
+      return month ? GetFormatedDateTime(new Date(month), "MM/yyyy") : "";
     }
   };
 

--- a/src/components/ReturnDateSelector.jsx
+++ b/src/components/ReturnDateSelector.jsx
@@ -4,7 +4,8 @@ import DatePicker from "react-datepicker";
 import { addMonths } from "date-fns";
 import {
   GetDueDateStatus,
-  GetFormattedDueDate
+  GetFormattedDueDate,
+  GetFormatedDateTime
 } from "../common/DatesUtilities";
 import { Labels } from "../common/Constants";
 import { GetIdByDescription } from "../common/LookupUtilities";
@@ -76,6 +77,12 @@ const ReturnInterval = props => {
     }
   };
 
+  const getMonth = monthIndex => {
+    if (Object.entries(months).length > 0) {
+      return GetFormatedDateTime(new Date(months[monthIndex]), "MM/yyyy");
+    }
+  };
+
   /** Ensure dates make it to form */
   useEffect(() => {
     setFieldValue("monthsToReport", months);
@@ -108,15 +115,21 @@ const ReturnInterval = props => {
             const id = `month-date-picker-${monthIndex}`;
             return (
               <div className="tt_month-picker" key={monthIndex}>
-                <label htmlFor={id}>{getMonthLabel(monthIndex)}</label>
-                <DatePicker
-                  id={id}
-                  selected={months[monthIndex]}
-                  onChange={date => handleDateChange(date, monthIndex)}
-                  startDate={startDate}
-                  dateFormat="MM/yyyy"
-                  showMonthYearPicker
-                />
+                {Object.entries(months).length > 0 || monthIndex === 0 ? (
+                  <label htmlFor={id}>{getMonthLabel(monthIndex)}</label>
+                ) : null}
+                {monthIndex === 0 ? (
+                  <DatePicker
+                    id={id}
+                    selected={months[monthIndex]}
+                    onChange={date => handleDateChange(date, monthIndex)}
+                    startDate={startDate}
+                    dateFormat="MM/yyyy"
+                    showMonthYearPicker
+                  />
+                ) : (
+                  <p>{getMonth(monthIndex)}</p>
+                )}
               </div>
             );
           })}


### PR DESCRIPTION
Removed the second and third months choices for quarterly and changed them to text values so they can be modified. 