### PR TITLE
Removed next due date logic and message

### DIFF
--- a/src/pages/ConfirmationPage.jsx
+++ b/src/pages/ConfirmationPage.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { GetFormattedDueDate } from "../common/DatesUtilities";
 import ConfirmationTable from "../components/ConfirmationTable";
 import { GetTransientTaxReturn } from "../services/ApiService";
 
@@ -18,7 +17,6 @@ const ConfirmationForm = props => {
     monthlyTaxCollected,
     monthlyInterest,
     monthlyNetRoomRental,
-    dueDate,
     formattedDueDate
   } = response;
 

--- a/src/pages/ConfirmationPage.jsx
+++ b/src/pages/ConfirmationPage.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { GetFormattedDueDate } from "../common/DatesUtilities";
 import ConfirmationTable from "../components/ConfirmationTable";
 import { GetTransientTaxReturn } from "../services/ApiService";
-import { addMonths } from "date-fns";
 
 const ConfirmationForm = props => {
   const { confirmationNumber = 0 } = props.match.params;
@@ -33,12 +32,6 @@ const ConfirmationForm = props => {
         props.history.push("/error", { ...error });
       });
   }, [confirmationNumber, props.history]);
-
-  const monthsToAdd = monthlyInterest && monthlyInterest.length === 1 ? 1 : 3;
-
-  const newDueDate = monthlyInterest
-    ? GetFormattedDueDate(addMonths(dueDate, monthsToAdd)).toString()
-    : null;
 
   const ConfirmationTableValues = [
     { id: 1, key: "Month of Return", value: monthSubmitted },
@@ -71,12 +64,6 @@ const ConfirmationForm = props => {
             Please present this number to the appropriate Budget and Finance
             Official when making inquiries in regards to your Transient
             Occupancy Tax Return.
-          </p>
-          <p>
-            <em>
-              You have signed up for {ReturnTypeDescription.toLowerCase()}{" "}
-              payments the due date for your next payment is {newDueDate}
-            </em>
           </p>
           <ConfirmationTable
             TaxDetailsHeader={"Transient Occupancy Tax Return Details:"}


### PR DESCRIPTION
This addresses an email request.

Per email request "4)	Remove this text from the Confirmation page AND email if it goes on the email, as well all agreed it’s confusing and to do it cleanly would be a challenge. You have signed up for monthly payments the due date for your next payment is June 30, 2019" from customer