### PR TITLE
Fix Interest calculation

### DIFF
--- a/src/common/Caculations.test.js
+++ b/src/common/Caculations.test.js
@@ -2,13 +2,8 @@ import { CalculateInterest, CalculatePenalty } from "./Calculations";
 
 describe("Interest Calculation", () => {
   test("should return the proper calculation when passed valid data based on the default interest rate of 1", () => {
-    const actual = CalculateInterest(100, 2, 0.1);
-    expect(actual).toEqual(21);
-  });
-
-  test("should return the proper calculation when passed valid data based on the default interest rate of 1", () => {
-    const actual = CalculateInterest(100, 4, 0.1);
-    expect(actual).toEqual(46.41);
+    const actual = CalculateInterest(10000, 2, 0.01);
+    expect(actual).toEqual(200);
   });
 
   test("should return zero if the payment is still considered on time", () => {

--- a/src/common/Caculations.test.js
+++ b/src/common/Caculations.test.js
@@ -2,12 +2,17 @@ import { CalculateInterest, CalculatePenalty } from "./Calculations";
 
 describe("Interest Calculation", () => {
   test("should return the proper calculation when passed valid data based on the default interest rate of 1", () => {
-    const actual = CalculateInterest(100, 4);
-    expect(actual).toEqual(4);
+    const actual = CalculateInterest(100, 2, 0.1);
+    expect(actual).toEqual(21);
+  });
+
+  test("should return the proper calculation when passed valid data based on the default interest rate of 1", () => {
+    const actual = CalculateInterest(100, 4, 0.1);
+    expect(actual).toEqual(46.41);
   });
 
   test("should return zero if the payment is still considered on time", () => {
-    const actual = CalculateInterest(100, 0);
+    const actual = CalculateInterest(100, 0, 0.1);
     expect(actual).toEqual(0);
   });
 });

--- a/src/common/Calculations.js
+++ b/src/common/Calculations.js
@@ -114,13 +114,13 @@ const GetCalculatedTotals = (fields = {}, monthsToReport, monthsLate = 0) => {
 
   if (monthsLate) {
     transientInterest = CalculateTotalsPerMonths(
-      [netRoomRentalCollections],
+      [transientTaxCollected],
       monthsToReport,
       total => CalculateInterest(total, monthsLate)
     );
 
     transientPenalty = CalculateTotalsPerMonths(
-      [netRoomRentalCollections],
+      [transientTaxCollected],
       monthsToReport,
       CalculatePenalty
     );

--- a/src/common/Calculations.js
+++ b/src/common/Calculations.js
@@ -4,13 +4,21 @@ import { RatesAndFees } from "./Constants";
  * Calculate the interest based on tax collected and the number of months late.
  * @param {number} taxCollected dollar amount to base the interest off
  * @param {number} numberOfMonthsLate number of months the user has failed to pay their tax
- * @param {number} interest - interest rate to charge as a decimal
+ * @param {number} interestRate - interest rate to charge as a decimal
  */
 const CalculateInterest = (
   taxCollected,
   numberOfMonthsLate,
-  interest = RatesAndFees.InterestRate
-) => taxCollected * interest * numberOfMonthsLate;
+  interestRate = RatesAndFees.InterestRate
+) => {
+  let taxPlusInterest = taxCollected;
+
+  for (let i = 0; i < numberOfMonthsLate; i++) {
+    taxPlusInterest = taxPlusInterest + taxPlusInterest * interestRate;
+  }
+
+  return taxPlusInterest - taxCollected;
+};
 
 /**
  * Calculate the penalty fee based on tax collected.

--- a/src/common/Calculations.js
+++ b/src/common/Calculations.js
@@ -10,15 +10,7 @@ const CalculateInterest = (
   taxCollected,
   numberOfMonthsLate,
   interestRate = RatesAndFees.InterestRate
-) => {
-  let taxPlusInterest = taxCollected;
-
-  for (let i = 0; i < numberOfMonthsLate; i++) {
-    taxPlusInterest = taxPlusInterest + taxPlusInterest * interestRate;
-  }
-
-  return taxPlusInterest - taxCollected;
-};
+) => taxCollected * numberOfMonthsLate * interestRate;
 
 /**
  * Calculate the penalty fee based on tax collected.

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -25,7 +25,7 @@ const Labels = {
   WhyDoWeNeedThis: "Why do we need this?",
   LegalNote:
     "I Declare under penalty of perjury that this return has been examined by me and to the best of my knowledge and belief is a true, correct and complete return.",
-  GrossOccupancy: "Gross Occupancy Tax Collected",
+  GrossOccupancy: "Gross Occupancy Revenue Collected",
   DaysRemaining: "Days remaining until due",
   DueDate: "Due Date",
   PastDue: "Past Due",

--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -52,8 +52,6 @@ const GetDueDateStatus = (filingForDate, dateOfFilingDate) => {
   const startDateOfFilingDate = startOfDay(dateOfFilingDate);
   const dateDifference = differenceInDays(dueDate, startDateOfFilingDate);
 
-  console.log(dateDifference);
-
   if (dateDifference > 0) {
     return {
       isLate: false,

--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -5,7 +5,7 @@ import {
   endOfMonth,
   format,
   startOfDay,
-  isEqual
+  startOfMonth
 } from "date-fns";
 import { Labels, DateTypes } from "./Constants";
 const DefaultDateFormat = "MMMM d, yyyy";
@@ -50,11 +50,9 @@ const GetFormatedDateTime = (dateToFormat, dateFormat) => {
 const GetDueDateStatus = (filingForDate, dateOfFilingDate) => {
   const dueDate = startOfDay(GetDueDate(filingForDate));
   const startDateOfFilingDate = startOfDay(dateOfFilingDate);
-  const isFilingDateEndOfMonth = isEqual(
-    startOfDay(endOfMonth(dateOfFilingDate)),
-    startDateOfFilingDate
-  );
   const dateDifference = differenceInDays(dueDate, startDateOfFilingDate);
+
+  console.log(dateDifference);
 
   if (dateDifference > 0) {
     return {
@@ -67,12 +65,12 @@ const GetDueDateStatus = (filingForDate, dateOfFilingDate) => {
   }
 
   /**
-   * Person will only be charged if it's the last day of the month.
-   * The ternary adds 1 to the difference in this case, to ensure they are charged.
+   * Add since 1 day late is considered 1 month late, but differenceInMonths returns 0 for anything under 1 month
    */
-  const monthDifference =
-    differenceInMonths(startDateOfFilingDate, dueDate) +
-    (isFilingDateEndOfMonth ? 1 : 0);
+  const monthDifference = differenceInMonths(
+    startOfMonth(startDateOfFilingDate),
+    startOfMonth(dueDate)
+  );
 
   return {
     isLate: true,

--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -4,7 +4,8 @@ import {
   differenceInMonths,
   endOfMonth,
   format,
-  startOfDay
+  startOfDay,
+  isEqual
 } from "date-fns";
 import { Labels, DateTypes } from "./Constants";
 const DefaultDateFormat = "MMMM d, yyyy";
@@ -49,6 +50,10 @@ const GetFormatedDateTime = (dateToFormat, dateFormat) => {
 const GetDueDateStatus = (filingForDate, dateOfFilingDate) => {
   const dueDate = startOfDay(GetDueDate(filingForDate));
   const startDateOfFilingDate = startOfDay(dateOfFilingDate);
+  const isFilingDateEndOfMonth = isEqual(
+    startOfDay(endOfMonth(dateOfFilingDate)),
+    startDateOfFilingDate
+  );
   const dateDifference = differenceInDays(dueDate, startDateOfFilingDate);
 
   if (dateDifference > 0) {
@@ -62,11 +67,12 @@ const GetDueDateStatus = (filingForDate, dateOfFilingDate) => {
   }
 
   /**
-   * Reverse dateOfFilingDate and dueDate from above to give us a positive number
-   * Add 1 to ensure that if it's 1 day after the due date it is considered 1 month late
+   * Person will only be charged if it's the last day of the month.
+   * The ternary adds 1 to the difference in this case, to ensure they are charged.
    */
   const monthDifference =
-    differenceInMonths(startDateOfFilingDate, dueDate) + 1;
+    differenceInMonths(startDateOfFilingDate, dueDate) +
+    (isFilingDateEndOfMonth ? 1 : 0);
 
   return {
     isLate: true,

--- a/src/common/DatesUtilities.test.js
+++ b/src/common/DatesUtilities.test.js
@@ -18,17 +18,31 @@ describe("Get Formatted Due Date", () => {
 });
 
 describe("Get Due Date Status", () => {
-  test("should past due status, when the date of filing is past than the due date", () => {
+  test("should past due status, when the date of filing is past than the due date by 1 day", () => {
     const actual = GetDueDateStatus(
-      new Date("July 1, 2019"),
-      new Date("December 15, 2019")
+      new Date("April 1, 2019"),
+      new Date("November 25, 2019")
     );
     expect(actual).toEqual({
       isLate: true,
-      value: 4,
+      value: 5,
       dateType: "month",
       label: "Past Due",
-      message: "4 months"
+      message: "5 months"
+    });
+  });
+
+  test("should past due status, when the date of filing is past than the due date by 1 day", () => {
+    const actual = GetDueDateStatus(
+      new Date("April 1, 2019"),
+      new Date("November 30, 2019")
+    );
+    expect(actual).toEqual({
+      isLate: true,
+      value: 6,
+      dateType: "month",
+      label: "Past Due",
+      message: "6 months"
     });
   });
 

--- a/src/common/DatesUtilities.test.js
+++ b/src/common/DatesUtilities.test.js
@@ -20,36 +20,8 @@ describe("Get Formatted Due Date", () => {
 describe("Get Due Date Status", () => {
   test("should past due status, when the date of filing is past than the due date by 1 day", () => {
     const actual = GetDueDateStatus(
-      new Date("April 1, 2019"),
-      new Date("November 25, 2019")
-    );
-    expect(actual).toEqual({
-      isLate: true,
-      value: 5,
-      dateType: "month",
-      label: "Past Due",
-      message: "5 months"
-    });
-  });
-
-  test("should past due status, when the date of filing is past than the due date by 1 day", () => {
-    const actual = GetDueDateStatus(
-      new Date("April 1, 2019"),
-      new Date("November 30, 2019")
-    );
-    expect(actual).toEqual({
-      isLate: true,
-      value: 6,
-      dateType: "month",
-      label: "Past Due",
-      message: "6 months"
-    });
-  });
-
-  test("should past due status, when the date of filing is past than the due date by 1 day", () => {
-    const actual = GetDueDateStatus(
-      new Date("July 1, 2019"),
-      new Date("September 1, 2019")
+      new Date("August 1, 2019"),
+      new Date("October 1, 2019")
     );
     expect(actual).toEqual({
       isLate: true,
@@ -57,6 +29,34 @@ describe("Get Due Date Status", () => {
       dateType: "month",
       label: "Past Due",
       message: "1 month"
+    });
+  });
+
+  test("should past due status, when the date of filing is at then end of a month with 30 days", () => {
+    const actual = GetDueDateStatus(
+      new Date("August 1, 2019"),
+      new Date("November 30, 2019")
+    );
+    expect(actual).toEqual({
+      isLate: true,
+      value: 2,
+      dateType: "month",
+      label: "Past Due",
+      message: "2 months"
+    });
+  });
+
+  test("should past due status, when the date of filing is at then end of a month with 31 days", () => {
+    const actual = GetDueDateStatus(
+      new Date("August 1, 2019"),
+      new Date("December 31, 2019")
+    );
+    expect(actual).toEqual({
+      isLate: true,
+      value: 3,
+      dateType: "month",
+      label: "Past Due",
+      message: "3 months"
     });
   });
 


### PR DESCRIPTION
Per an email


> Let’s say I’m paying now (11/25) for the month of April. That payment would have been due May 30. 

> June, July, August, September and October should all be counted in the # of months late (5 months total) – but NOT November (currently November IS being included).

> Unless the person is submitting the payment on the last day of the month, that month is NOT to be counted towards the number of months to charge the business interest for. So if I were paying on 11/30 for the month of April, then November WOULD be included in the count of # of months late (6 months total).

- Adjusted tests to match criteria
- Updated logic to pass tests 
