### PR TITLE
added clearix to adjust for label being outside of the fieldset

### DIFF
--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -92,6 +92,7 @@ const Step = props => {
   return (
     <fieldset {...rest}>
       <legend>{label}</legend>
+      <div className="clearfix"></div>
       {componentWithProps}
     </fieldset>
   );


### PR DESCRIPTION
Fixes float issue introduced in #166 

![image](https://user-images.githubusercontent.com/1933400/71265861-2e856180-2315-11ea-86de-dd0757359226.png)
