### PR TITLE
Fix Issues with Form Data not persisting when navigating back and forth

### DIFF
--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -32,9 +32,19 @@ const Step = props => {
     onPrevClick(prevStep);
   };
 
-  const onValidSubmission = (values, shouldResetSteps = true) => {
-    if (shouldResetSteps) {
-      onFormSubmission(stepList, values, formik.values, shouldResetSteps);
+  /**
+   * Call callback (onFormSubmission), set main formik field values, navigate to the next form
+   * @param {object} values form values from form panel to be inserted into the paged form's context
+   * @param {boolean} shouldSkipFormSubmission manually skip callback, a case for this would be when nothing has changed in the form.
+   */
+  const onValidSubmission = (values, shouldSkipFormSubmission = true) => {
+    if (shouldSkipFormSubmission) {
+      onFormSubmission(
+        stepList,
+        values,
+        formik.values,
+        shouldSkipFormSubmission
+      );
     }
     formik.setValues({ ...formik.values, ...values });
     onNextClick(nextStep);

--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -32,8 +32,8 @@ const Step = props => {
     onPrevClick(prevStep);
   };
 
-  const onValidSubmission = values => {
-    onFormSubmission(stepList, values, formik.values);
+  const onValidSubmission = (values, shouldResetSteps = true) => {
+    onFormSubmission(stepList, values, formik.values, shouldResetSteps);
     formik.setValues({ ...formik.values, ...values });
     onNextClick(nextStep);
   };

--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -33,7 +33,9 @@ const Step = props => {
   };
 
   const onValidSubmission = (values, shouldResetSteps = true) => {
-    onFormSubmission(stepList, values, formik.values, shouldResetSteps);
+    if (shouldResetSteps) {
+      onFormSubmission(stepList, values, formik.values, shouldResetSteps);
+    }
     formik.setValues({ ...formik.values, ...values });
     onNextClick(nextStep);
   };

--- a/src/components/forms/MultiPageForm.jsx
+++ b/src/components/forms/MultiPageForm.jsx
@@ -13,6 +13,8 @@ const MultiPageForm = props => {
     setActiveStep(stepNumber);
   };
 
+  console.log(steps);
+
   return (
     <div className="tt_form">
       <TransientTaxTabs
@@ -31,7 +33,7 @@ const MultiPageForm = props => {
         {props => (
           <div onSubmit={props.handleSubmit}>
             {steps.map(step => {
-              const { stepNumber } = step;
+              const { id, stepNumber } = step;
               const isActiveStep = stepNumber === activeStep;
               const nextStep =
                 stepNumber < steps.length ? stepNumber + 1 : null;
@@ -40,7 +42,7 @@ const MultiPageForm = props => {
               const tabs = steps;
               return (
                 <Step
-                  key={stepNumber}
+                  key={id}
                   {...step}
                   stepList={stepList}
                   isLastStep={isLastStep}

--- a/src/components/forms/MultiPageForm.jsx
+++ b/src/components/forms/MultiPageForm.jsx
@@ -13,8 +13,6 @@ const MultiPageForm = props => {
     setActiveStep(stepNumber);
   };
 
-  console.log(steps);
-
   return (
     <div className="tt_form">
       <TransientTaxTabs

--- a/src/components/forms/PaymentOptionsForm.jsx
+++ b/src/components/forms/PaymentOptionsForm.jsx
@@ -21,6 +21,10 @@ const PaymentOptionsForm = props => {
   } = props;
   const [filingTypes, setFilingTypes] = useState([]);
   const [paymentInterval, setPaymentInterval] = useState();
+  const {
+    paymentInterval: intervalFromFormik,
+    monthsToReport: monthsToReportFromFormik
+  } = formik.values;
 
   useEffect(() => {
     if (filingTypes.length === 0) {
@@ -44,7 +48,12 @@ const PaymentOptionsForm = props => {
     <Formik
       initialValues={{ paymentInterval: "", monthsToReport: {} }}
       onSubmit={values => {
-        onValidSubmission(values);
+        const { paymentInterval, monthsToReport } = values;
+        const hasChange =
+          paymentInterval !== intervalFromFormik ||
+          monthsToReport !== monthsToReportFromFormik;
+
+        onValidSubmission(values, hasChange);
       }}
       validationSchema={Yup.object({
         paymentInterval: Yup.string()

--- a/src/components/forms/PaymentOptionsForm.jsx
+++ b/src/components/forms/PaymentOptionsForm.jsx
@@ -41,7 +41,7 @@ const PaymentOptionsForm = props => {
   const handleOnChange = onClick => {
     formik.setFieldValue("monthlyData", []);
     formik.setFieldValue("monthsToReport", {});
-    formik.setFieldValue(("exemptions", []));
+    formik.setFieldValue("exemptions", []);
     setPaymentInterval(onClick.currentTarget.value);
   };
 

--- a/src/components/forms/PaymentOptionsForm.jsx
+++ b/src/components/forms/PaymentOptionsForm.jsx
@@ -40,7 +40,8 @@ const PaymentOptionsForm = props => {
 
   const handleOnChange = onClick => {
     formik.setFieldValue("monthlyData", []);
-    formik.setFieldValue("monthsToReport", []);
+    formik.setFieldValue("monthsToReport", {});
+    formik.setFieldValue(("exemptions", []));
     setPaymentInterval(onClick.currentTarget.value);
   };
 

--- a/src/steps/StepList.js
+++ b/src/steps/StepList.js
@@ -28,10 +28,22 @@ class StepList {
   }
 
   /**
+   * Remove step based on a regular expression
+   * @param {string} prop property you wish to use to filter
+   * @param {RegExp} regExpression regex to filter property by
+   */
+  removeStep(prop, regExpression) {
+    const filteredSteps = this.steps.filter(
+      step => !step[prop].match(regExpression)
+    );
+    this.steps = generateStepNumber(filteredSteps);
+  }
+
+  /**
    * Remove a step based on given unique id
    * @param {string} idToRemove unique id to identify a certain step
    */
-  removeStep(idToRemove) {
+  removeStepById(idToRemove) {
     const filteredSteps = this.steps.filter(({ id }) => id !== idToRemove);
     this.steps = generateStepNumber(filteredSteps);
   }

--- a/src/steps/StepList.test.js
+++ b/src/steps/StepList.test.js
@@ -51,7 +51,7 @@ describe("remove step by reg ex", () => {
       })
     ]);
 
-    stepList.removeStep("label", /^((?!tep 3).)*$/gim);
+    stepList.removeStep("label", /^.*tep\s3.*$/gim);
 
     expect(stepList.steps).toEqual([
       new Step({

--- a/src/steps/StepList.test.js
+++ b/src/steps/StepList.test.js
@@ -33,7 +33,42 @@ describe("add step", () => {
   });
 });
 
-describe("remove step", () => {
+describe("remove step by reg ex", () => {
+  test("should remove a step based on a regex expression", () => {
+    // Initialize Step List
+    const stepList = new StepList([
+      new Step({
+        id: "basic-form",
+        label: "Step 1"
+      }),
+      new Step({
+        id: "advanced-form",
+        label: "Step 2"
+      }),
+      new Step({
+        id: "login",
+        label: "Step 3"
+      })
+    ]);
+
+    stepList.removeStep("label", /^((?!tep 3).)*$/gim);
+
+    expect(stepList.steps).toEqual([
+      new Step({
+        id: "basic-form",
+        stepNumber: 1,
+        label: "Step 1"
+      }),
+      new Step({
+        id: "advanced-form",
+        stepNumber: 2,
+        label: "Step 2"
+      })
+    ]);
+  });
+});
+
+describe("remove step by id", () => {
   test("should remove a step based on a valid id", () => {
     // Initialize Step List
     const stepList = new StepList([
@@ -51,7 +86,7 @@ describe("remove step", () => {
       })
     ]);
 
-    stepList.removeStep("advanced-form");
+    stepList.removeStepById("advanced-form");
 
     expect(stepList.steps).toEqual([
       new Step({

--- a/src/steps/TransientTaxStepList.js
+++ b/src/steps/TransientTaxStepList.js
@@ -49,8 +49,17 @@ const onPaymentFormSubmission = ({
       stepList.addStep(exemptionStep, previousStepId);
     }
   } else {
-    stepList.removeStep(exemptionStepId);
+    stepList.removeStepById(exemptionStepId);
   }
+};
+
+/**
+ * Remove existing payment form steps
+ * @param {object} stepList
+ */
+const removeExistingPaymentFormSteps = stepList => {
+  const paymentFormRegex = /^((?!payment-form-).)*$/gim;
+  stepList.removeStep("id", paymentFormRegex);
 };
 
 /**
@@ -67,6 +76,8 @@ const onPaymentSelectionSubmission = (
   if (!shouldResetSteps) {
     return;
   }
+
+  removeExistingPaymentFormSteps(stepList);
 
   let stepToInsertAfter = "payment-selection";
   Object.keys(monthsToReport).forEach((monthKey, monthIndex) => {

--- a/src/steps/TransientTaxStepList.js
+++ b/src/steps/TransientTaxStepList.js
@@ -58,7 +58,7 @@ const onPaymentFormSubmission = ({
  * @param {object} stepList
  */
 const removeExistingPaymentFormSteps = stepList => {
-  const paymentFormRegex = /^((?!payment-form-).)*$/gim;
+  const paymentFormRegex = /^payment-form-.*$/gi;
   stepList.removeStep("id", paymentFormRegex);
 };
 

--- a/src/steps/TransientTaxStepList.js
+++ b/src/steps/TransientTaxStepList.js
@@ -58,8 +58,16 @@ const onPaymentFormSubmission = ({
  * @param {StepList} stepList
  * @param {object} currentFormValues formik values for the current step form
  */
-const onPaymentSelectionSubmission = (stepList, { monthsToReport }) => {
-  stepList.reset();
+const onPaymentSelectionSubmission = (
+  stepList,
+  { monthsToReport },
+  formikValues,
+  shouldResetSteps
+) => {
+  if (!shouldResetSteps) {
+    return;
+  }
+
   let stepToInsertAfter = "payment-selection";
   Object.keys(monthsToReport).forEach((monthKey, monthIndex) => {
     const date = monthsToReport[monthKey];

--- a/src/steps/TransientTaxStepList.js
+++ b/src/steps/TransientTaxStepList.js
@@ -67,16 +67,7 @@ const removeExistingPaymentFormSteps = stepList => {
  * @param {StepList} stepList
  * @param {object} currentFormValues formik values for the current step form
  */
-const onPaymentSelectionSubmission = (
-  stepList,
-  { monthsToReport },
-  formikValues,
-  shouldResetSteps
-) => {
-  if (!shouldResetSteps) {
-    return;
-  }
-
+const onPaymentSelectionSubmission = (stepList, { monthsToReport }) => {
   removeExistingPaymentFormSteps(stepList);
 
   let stepToInsertAfter = "payment-selection";


### PR DESCRIPTION
Addresses #165 

In the scenario listed in issue #165, the step list was being reset every time they payment was submitted. 

In order to fix this, the submission function for that form, now checks to see if there are any changes. If there aren't, nothing happens, and you can use the form as you would expect.

This exposed another issue, in which when you changed the payment intervals the existing panels would not be removed from the step list, causing issues with form submissions.

The user should now be able to go back to the payment interval screen and receive consistent behavior:

- When no date changes, the form will remain the same
- When the date changes or interval changes the form will reset