### PR TITLE
Fix IE 11 Currency Input Not Working

### DIFF
--- a/src/components/PaymentField.jsx
+++ b/src/components/PaymentField.jsx
@@ -22,6 +22,7 @@ const CustomInputComponent = ({
   );
 
   const handleChange = formattedNumber => {
+    /** IE 11 valueAsNumber does not work, so we have to use the string "value" from the target */
     const { value, valueAsNumber } = formattedNumber.target;
     const currencyValue = valueAsNumber || parseFloat(value);
 

--- a/src/components/PaymentField.jsx
+++ b/src/components/PaymentField.jsx
@@ -22,11 +22,13 @@ const CustomInputComponent = ({
   );
 
   const handleChange = formattedNumber => {
-    const { valueAsNumber } = formattedNumber.target;
-    setValue(!valueAsNumber ? undefined : Math.abs(valueAsNumber));
+    const { value, valueAsNumber } = formattedNumber.target;
+    const currencyValue = valueAsNumber || parseFloat(value);
+
+    setValue(!currencyValue ? undefined : Math.abs(currencyValue));
     setFieldValue(
       name,
-      !valueAsNumber ? 0 : isNegativeValue ? -valueAsNumber : valueAsNumber
+      !currencyValue ? 0 : isNegativeValue ? -currencyValue : currencyValue
     );
   };
 


### PR DESCRIPTION
valueAsNumber was not working in ie11, so we added, the ability to parse the value if valueAsNumber does not work.