### PR TITLE
Add date range forinterval

### DIFF
--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -82,10 +82,35 @@ const GetDueDateStatus = (filingForDate, dateOfFilingDate) => {
   };
 };
 
+const hasExemption = ({
+  governmentExemptRentalCollected = 0,
+  nonTransientRentalCollected = 0
+}) => governmentExemptRentalCollected + nonTransientRentalCollected < 0;
+
+/**
+ * Gets the minimum date
+ * @param {*} monthlyData
+ */
+const GetMinExemptionStartDate = (monthlyData = []) => {
+  const { month, year } = monthlyData.find(hasExemption);
+  return new Date(year, month - 1, 1);
+};
+
+/**
+ *
+ * @param {*} monthlyData
+ */
+const GetMaxExemptionEndDate = (monthlyData = []) => {
+  const { month, year } = monthlyData.filter(hasExemption).pop();
+  return endOfMonth(new Date(year, month - 1, 1));
+};
+
 export {
   DefaultDateFormat,
   GetDueDate,
   GetFormattedDueDate,
   GetDueDateStatus,
-  GetFormatedDateTime
+  GetFormatedDateTime,
+  GetMinExemptionStartDate,
+  GetMaxExemptionEndDate
 };

--- a/src/common/DatesUtilities.test.js
+++ b/src/common/DatesUtilities.test.js
@@ -1,4 +1,9 @@
-import { GetDueDateStatus, GetFormattedDueDate } from "./DatesUtilities";
+import {
+  GetDueDateStatus,
+  GetFormattedDueDate,
+  GetMaxExemptionEndDate,
+  GetMinExemptionStartDate
+} from "./DatesUtilities";
 
 describe("Get Formatted Due Date", () => {
   test("should return the proper due date on a normal year", () => {
@@ -96,5 +101,61 @@ describe("Get Due Date Status", () => {
         message: "1 day"
       })
     );
+  });
+});
+
+describe("Get Min Date", () => {
+  test("should return the first month with an exemption", () => {
+    const actual = GetMinExemptionStartDate([
+      {
+        month: 10,
+        year: 2019,
+        governmentExemptRentalCollected: 0,
+        nonTransientRentalCollected: 0
+      },
+      {
+        month: 11,
+        year: 2019,
+        governmentExemptRentalCollected: -1,
+        nonTransientRentalCollected: 0
+      },
+      {
+        month: 12,
+        year: 2019,
+        governmentExemptRentalCollected: 0,
+        nonTransientRentalCollected: -10
+      }
+    ]);
+
+    expect(actual).toEqual(new Date(2019, 10, 1)); // November 1, 2019
+  });
+});
+
+describe("Get Max Date", () => {
+  test("should return the last month with an exemption", () => {
+    const actual = GetMaxExemptionEndDate([
+      {
+        month: 10,
+        year: 2019,
+        governmentExemptRentalCollected: 0,
+        nonTransientRentalCollected: 0
+      },
+      {
+        month: 11,
+        year: 2019,
+        governmentExemptRentalCollected: -1,
+        nonTransientRentalCollected: 0
+      },
+      {
+        month: 12,
+        year: 2019,
+        governmentExemptRentalCollected: 0,
+        nonTransientRentalCollected: -10
+      }
+    ]);
+
+    expect(actual.toLocaleDateString()).toEqual(
+      new Date(2019, 11, 31).toLocaleDateString()
+    ); // December 31, 2019
   });
 });

--- a/src/components/formik/DateRangeSelector.jsx
+++ b/src/components/formik/DateRangeSelector.jsx
@@ -1,14 +1,15 @@
 import React, { useEffect, useState } from "react";
 
 import DatePicker from "react-datepicker";
-import { addDays } from "date-fns";
 
 const DateRangeSelector = props => {
   const {
     fromDate: fromDateFromProps,
     toDate: toDateFromProps,
     handleChange = () => {},
-    onClick = () => {}
+    onClick = () => {},
+    minDate = new Date(),
+    maxDate = new Date()
   } = props;
   const [fromDate, setFromDate] = useState(fromDateFromProps);
   const [toDate, setToDate] = useState(toDateFromProps);
@@ -49,8 +50,10 @@ const DateRangeSelector = props => {
           selected={fromDate}
           onChange={handleFromDateChange}
           onClickOutside={() => onClick(null, fromDateId)}
-          maxDate={addDays(toDate, -1)}
+          minDate={minDate}
+          maxDate={maxDate}
           selectsStart
+          startDate={minDate}
         />
       </div>
       <div>
@@ -60,7 +63,8 @@ const DateRangeSelector = props => {
           name={toDateId}
           selected={toDate}
           onChange={handleToDateChange}
-          minDate={addDays(fromDate, 1)}
+          minDate={minDate}
+          maxDate={maxDate}
           selectsEnd
           startDate={fromDate}
           onClickOutside={() => onClick(null, toDateId)}

--- a/src/components/formik/ExemptionCertificateField.jsx
+++ b/src/components/formik/ExemptionCertificateField.jsx
@@ -13,7 +13,7 @@ const ExemptionCertificate = ({
   ...props
 }) => {
   const { setFieldValue } = form;
-  const { exemptions: exemptionsFromProps = [] } = props;
+  const { exemptions: exemptionsFromProps = [], monthlyData = [] } = props;
   const [exemption, setExemption] = useState({});
   const [exemptions, setExemptions] = useState(exemptionsFromProps);
   const [isSelectorFormDirty, setIsSelectorFormDirty] = useState(0);
@@ -55,6 +55,7 @@ const ExemptionCertificate = ({
       <ExemptionSelector
         exemption={exemption}
         onExemptionSave={saveExemption}
+        monthlyData={monthlyData}
       />
       {exemptions.length > 0 && (
         <ExemptionsList

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -1,3 +1,7 @@
+import {
+  GetMaxExemptionEndDate,
+  GetMinExemptionStartDate
+} from "../../common/DatesUtilities";
 import React, { useEffect, useState } from "react";
 
 import BasicErrorMessage from "../BasicErrorMessage";
@@ -11,7 +15,8 @@ import { RadioButton } from "../../common/RadioButton";
 const ExemptionSelector = props => {
   const {
     exemption: exemptionFromProps = {},
-    onExemptionSave = () => {}
+    onExemptionSave = () => {},
+    monthlyData = []
   } = props;
   const [isLoading, setIsLoading] = useState(true);
   const [exemptionTypes, setExemptionTypes] = useState([]);
@@ -21,6 +26,8 @@ const ExemptionSelector = props => {
     GetExemptionFormErrors(exemptionFromProps)
   );
   const [exemption, setExemption] = useState(exemptionFromProps);
+  const minDate = GetMinExemptionStartDate(monthlyData);
+  const maxDate = GetMaxExemptionEndDate(monthlyData);
 
   useEffect(() => {
     if (exemptionTypes.length === 0) {
@@ -127,6 +134,8 @@ const ExemptionSelector = props => {
         toDate={exemption.toDate}
         handleChange={handleExemptionDateChange}
         onClick={handleFieldClick}
+        minDate={minDate}
+        maxDate={maxDate}
       />
       {(touched.fromDate || touched.toDate) &&
         formErrors.some(

--- a/src/components/forms/ExemptionCertificateForm.jsx
+++ b/src/components/forms/ExemptionCertificateForm.jsx
@@ -43,7 +43,10 @@ const ExemptionCertificateForm = props => {
         <Form>
           <PromptIfDirty />
           <div className="form-1">
-            <ExemptionCertificateField exemptions={exemptions} />
+            <ExemptionCertificateField
+              exemptions={exemptions}
+              monthlyData={monthlyData}
+            />
             <ErrorMessage name="exemptions" />
           </div>
           <div className="tt_form-controls">

--- a/src/components/forms/PaymentOptionsForm.jsx
+++ b/src/components/forms/PaymentOptionsForm.jsx
@@ -64,6 +64,7 @@ const PaymentOptionsForm = props => {
         const isQuarterly = paymentInterval === quarterlyId;
 
         const handleIntervalChange = () => {
+          setFieldValue("exemptions", [], false);
           setFieldValue(
             "monthsToReport",
             {

--- a/src/components/forms/PaymentOptionsForm.jsx
+++ b/src/components/forms/PaymentOptionsForm.jsx
@@ -65,6 +65,7 @@ const PaymentOptionsForm = props => {
 
         const handleIntervalChange = () => {
           setFieldValue("exemptions", [], false);
+          setFieldValue("monthlyData", []);
           setFieldValue(
             "monthsToReport",
             {


### PR DESCRIPTION
Resolves #192 

Ensures date range is within the month(s) selected on the interval screen. 

There is one known issue, that on both the from and to dates, the last month is always shown, if quartely, this is a know issue with react-datepicker https://github.com/Hacker0x01/react-datepicker/issues/1697