### PR TITLE
renamed compponent

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -204,6 +204,7 @@ label.tt_has-errors {
   width: 0 !important;
 }
 
+@import "./styles/components/progress-tabs";
 @import "./styles/components/currency-input";
 
 .tt_is-editing {

--- a/src/components/MultiPageForm.jsx
+++ b/src/components/MultiPageForm.jsx
@@ -1,8 +1,8 @@
 import { Formik } from "formik";
+import ProgressTabs from "./ProgressTabs";
 import React from "react";
 import { Redirect } from "react-router-dom";
 import Step from "./Step";
-import TransientTaxTabs from "./TransientTaxTabs";
 
 const MultiPageForm = props => {
   const {
@@ -38,7 +38,7 @@ const MultiPageForm = props => {
 
   return (
     <div className="tt_form">
-      <TransientTaxTabs
+      <ProgressTabs
         panelGroups={panelGroups}
         tabs={steps}
         activeStep={activeStep.stepNumber}

--- a/src/components/ProgressTabs.jsx
+++ b/src/components/ProgressTabs.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classnames from "classnames";
 
 const ProgressTabs = props => {
   const { panelGroups = [], tabs, activeStep } = props;
@@ -9,13 +10,17 @@ const ProgressTabs = props => {
     tabs.find(step => step.stepNumber === activeStepId);
 
   return (
-    <div className="bc-citysourced-reporter">
-      <ol className="bc-citysourced-reporter-steps">
+    <div className="bc_progress-tabs_container">
+      <ol className="bc_progress-tabs">
         {itemsToMap.map(item => {
           const step = hasPanelGroups ? getStepByPanelGroup(activeStep) : item;
           const isActiveOrCompletedItem = hasPanelGroups
             ? step.panelGroupId >= item.id
             : step.stepNumber <= activeStep;
+          const cssClasses = classnames(
+            "bc_progress-tabs_tab",
+            isActiveOrCompletedItem ? "highlight" : ""
+          );
 
           return (
             <li
@@ -23,7 +28,7 @@ const ProgressTabs = props => {
               style={{
                 display: step.isHidden ? "none" : "block"
               }}
-              className={isActiveOrCompletedItem ? "highlight" : ""}
+              className={cssClasses}
             >
               {item.label}
             </li>

--- a/src/components/ProgressTabs.jsx
+++ b/src/components/ProgressTabs.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const TransientTaxTabs = props => {
+const ProgressTabs = props => {
   const { panelGroups = [], tabs, activeStep } = props;
   const hasPanelGroups = panelGroups.length > 0;
   const itemsToMap = hasPanelGroups ? panelGroups : tabs;
@@ -34,4 +34,4 @@ const TransientTaxTabs = props => {
   );
 };
 
-export default TransientTaxTabs;
+export default ProgressTabs;

--- a/src/styles/components/progress-tabs.scss
+++ b/src/styles/components/progress-tabs.scss
@@ -1,0 +1,102 @@
+$gold: #feb30c;
+
+.bc_progress-tabs {
+  display: flex;
+  list-style-type: none;
+  padding: 0;
+}
+
+.bc_progress-tabs_tab {
+  background-color: #ebebeb;
+  color: #444;
+  flex: 1 1 auto;
+  font-family: Patua One, sans-serif;
+  margin: 0 10px;
+  padding: 15px;
+  height: 40px;
+  line-height: 20px;
+  position: relative;
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
+
+  &:after,
+  &:before {
+    content: "";
+    height: 0;
+    position: absolute;
+    width: 0;
+  }
+
+  &:before {
+    border-top: 35px solid #ebebeb;
+    border-bottom: 35px solid #ebebeb;
+    border-left: 15px solid transparent;
+    left: -15px;
+    top: 0;
+  }
+
+  &:after {
+    border-top: 35px solid transparent;
+    border-bottom: 35px solid transparent;
+    border-left: 15px solid #ebebeb;
+    right: -15px;
+    top: 0;
+  }
+
+  &:first-child {
+    margin-left: 0;
+
+    &:before {
+      border: none;
+    }
+  }
+
+  &:last-child {
+    list-style: none;
+    margin-right: 0;
+
+    &:after {
+      border: none;
+    }
+  }
+
+  &.highlight {
+    background-color: $gold;
+
+    &:before {
+      border-top-color: $gold;
+      border-bottom-color: $gold;
+    }
+
+    &:after {
+      border-left-color: $gold;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .bc_progress-tabs {
+    display: block;
+    padding-right: 1em;
+    list-style-type: decimal;
+    list-style-position: inside;
+  }
+
+  .bc_progress-tabs_tab {
+    display: list-item;
+    float: none;
+    height: auto;
+    line-height: 1.4em;
+    margin: 0 0 2px;
+    padding: 0.5em;
+    width: 100%;
+
+    br,
+    &:after,
+    &:before,
+    &:last-child {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
Resolves #148 

Changes the component to be more generic by:

- Renaming component to ProgressTabs
- Adding styles to the app

This will allow this to be moved to it's own component if needed easier.