### PR TITLE
Error page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import { Redirect, Route, HashRouter as Router } from "react-router-dom";
 import { Config } from "@baltimorecounty/javascript-utilities";
 import ConfirmationPage from "./pages/ConfirmationPage";
 import ErrorPage from "./pages/ErrorPage";
+import { GetError } from "./common/ErrorUtility";
+import { GetQueryParam } from "./common/Routing";
 import MultiPageForm from "./components/MultiPageForm";
 import React from "react";
 import TransientTaxStepList from "./steps/TransientTaxStepList";
@@ -51,7 +53,15 @@ const App = () => (
         path="/confirmation/:confirmationNumber"
         component={ConfirmationPage}
       />
-      <Route exact path="/error/:errorType" component={ErrorPage} />
+      <Route
+        exact
+        path="/error/:errorType"
+        render={({ match = {} }) => {
+          const errorType = GetQueryParam(match, "errorType");
+          const { heading, message } = GetError(errorType);
+          return <ErrorPage heading={heading} message={message} />;
+        }}
+      />
     </Router>
   </div>
 );

--- a/src/common/ErrorUtility.js
+++ b/src/common/ErrorUtility.js
@@ -1,4 +1,27 @@
 const ErrorPath = error =>
-  `/error/${error.response ? "invalidConfirmation" : "network"} `;
+  `/error/${error.response ? "invalidConfirmation" : "network"}`;
 
-export { ErrorPath };
+/**
+ * Get a heading and message for a given error type
+ * @param {string} errorType type of error
+ */
+const GetError = (errorType = "") => {
+  switch (errorType.toLowerCase()) {
+    case "invalidconfirmation": {
+      return {
+        heading: "Invalid Confirmation Number",
+        message:
+          "You have provided an invalid confirmation number. Please try submitting your Transient Occupancy Tax Return again. "
+      };
+    }
+    default: {
+      return {
+        heading: "System Error",
+        message:
+          "The system has encountered an error. Please wait a few minutes and try again."
+      };
+    }
+  }
+};
+
+export { ErrorPath, GetError };

--- a/src/common/ErrorUtility.js
+++ b/src/common/ErrorUtility.js
@@ -11,7 +11,7 @@ const GetError = (errorType = "") => {
       return {
         heading: "Invalid Confirmation Number",
         message:
-          "You have provided an invalid confirmation number. Please try submitting your Transient Occupancy Tax Return again. "
+          "The confirmation number provided in the url is invalid. Please double check your confirmation email for the link to your Transient Tax Return details."
       };
     }
     default: {

--- a/src/common/ErrorUtility.test.js
+++ b/src/common/ErrorUtility.test.js
@@ -1,0 +1,13 @@
+import { GetError } from "./ErrorUtility";
+
+describe("GetError", () => {
+  test("should return a confirmation error object", () => {
+    const actual = GetError("invalidConfirmation");
+    expect(actual.heading).toEqual("Invalid Confirmation Number");
+  });
+
+  test("should return a system error for any error apart from a confirmation error", () => {
+    const actual = GetError("network");
+    expect(actual.heading).toEqual("System Error");
+  });
+});

--- a/src/common/Routing.js
+++ b/src/common/Routing.js
@@ -1,0 +1,11 @@
+/**
+ * Gets query param value for a given match (react-router)
+ * @param {object} match object react router provides for query params
+ * @param {string} key query param key of the value you wish to retrieve
+ */
+const GetQueryParam = (match = {}, key = "") => {
+  const { params = {} } = match;
+  return params[key] ? params[key].trim() : null;
+};
+
+export { GetQueryParam };

--- a/src/common/Routing.test.js
+++ b/src/common/Routing.test.js
@@ -1,0 +1,20 @@
+import { GetQueryParam } from "./Routing";
+
+describe("GetQueryParam", () => {
+  test("should return null if match is empty", () => {
+    const actual = GetQueryParam();
+    expect(actual).toEqual(null);
+  });
+
+  test("should return value for valid key and match", () => {
+    const actual = GetQueryParam(
+      {
+        params: {
+          error: "really bad"
+        }
+      },
+      "error"
+    );
+    expect(actual).toEqual("really bad");
+  });
+});

--- a/src/components/MultiPageForm.jsx
+++ b/src/components/MultiPageForm.jsx
@@ -3,6 +3,7 @@ import ProgressTabs from "./ProgressTabs";
 import React from "react";
 import { Redirect } from "react-router-dom";
 import Step from "./Step";
+import useHasNetworkError from "./hooks/useHasNetworkError";
 
 const MultiPageForm = props => {
   const {
@@ -15,6 +16,11 @@ const MultiPageForm = props => {
   const currentStepIndex = steps.findIndex(
     x => x.id.toLowerCase() === stepId.toLowerCase()
   );
+  const { hasNetworkError, isLoading } = useHasNetworkError();
+
+  if (hasNetworkError) {
+    return <Redirect to="/error/network" />;
+  }
 
   if (currentStepIndex === -1) {
     return <Redirect to="/steps/basic-information" />;
@@ -36,7 +42,9 @@ const MultiPageForm = props => {
     isLastStep
   };
 
-  return (
+  return isLoading ? (
+    <p>Loading Form...</p>
+  ) : (
     <div className="tt_form">
       <ProgressTabs
         panelGroups={panelGroups}

--- a/src/components/hooks/useHasNetworkError.js
+++ b/src/components/hooks/useHasNetworkError.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+import { GetStatus } from "../../services/ApiService";
+
+const useHasNetworkError = () => {
+  const [hasNetworkError, setHasNetworkError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    GetStatus()
+      .catch(() => {
+        setHasNetworkError(true);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  return { hasNetworkError, isLoading };
+};
+
+export default useHasNetworkError;

--- a/src/pages/ConfirmationPage.jsx
+++ b/src/pages/ConfirmationPage.jsx
@@ -3,8 +3,10 @@ import React, { useEffect, useState } from "react";
 import Address from "../components/Address";
 import { BudgetAndFinanceOfficeAddress } from "../common/Constants";
 import { ErrorPath } from "../common/ErrorUtility";
+import { GetQueryParam } from "../common/Routing";
 import { GetReturnSummaryValues } from "../data/TaxReturnMapper";
 import { GetTransientTaxReturn } from "../services/ApiService";
+import { Redirect } from "react-router-dom";
 import ReturnSummary from "../components/ReturnSummary";
 import { format } from "date-fns";
 
@@ -14,8 +16,8 @@ const {
   City,
   Street
 } = BudgetAndFinanceOfficeAddress;
-const ConfirmationForm = props => {
-  const { confirmationNumber = 0 } = props.match.params;
+const ConfirmationForm = ({ match = {} }) => {
+  const confirmationNumber = GetQueryParam(match, "confirmationNumber") || 0;
   const [taxReturn, setTaxReturn] = useState({});
   const [isLoading, setIsLoading] = useState(true);
   const {
@@ -35,10 +37,10 @@ const ConfirmationForm = props => {
         setTaxReturn(response || {});
         setIsLoading(false);
       })
-      .catch(error => {
-        props.history.push(ErrorPath(error), { ...error });
+      .catch(() => {
+        return <Redirect path="/error/network" />;
       });
-  }, [confirmationNumber, props.history]);
+  }, [confirmationNumber]);
 
   return (
     <div>

--- a/src/pages/ConfirmationPage.jsx
+++ b/src/pages/ConfirmationPage.jsx
@@ -9,6 +9,7 @@ import { GetTransientTaxReturn } from "../services/ApiService";
 import { Redirect } from "react-router-dom";
 import ReturnSummary from "../components/ReturnSummary";
 import { format } from "date-fns";
+import useHasNetworkError from "../components/hooks/useHasNetworkError";
 
 const {
   Organization,
@@ -17,6 +18,8 @@ const {
   Street
 } = BudgetAndFinanceOfficeAddress;
 const ConfirmationForm = ({ match = {} }) => {
+  const { hasNetworkError } = useHasNetworkError();
+  const [hasConfirmationError, setHasConfirmationError] = useState(false);
   const confirmationNumber = GetQueryParam(match, "confirmationNumber") || 0;
   const [taxReturn, setTaxReturn] = useState({});
   const [isLoading, setIsLoading] = useState(true);
@@ -38,9 +41,13 @@ const ConfirmationForm = ({ match = {} }) => {
         setIsLoading(false);
       })
       .catch(() => {
-        return <Redirect path="/error/network" />;
+        setHasConfirmationError(true);
       });
   }, [confirmationNumber]);
+
+  if (hasNetworkError || hasConfirmationError) {
+    return <Redirect to="/error/network" />;
+  }
 
   return (
     <div>

--- a/src/pages/ConfirmationPage.jsx
+++ b/src/pages/ConfirmationPage.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 
 import Address from "../components/Address";
 import { BudgetAndFinanceOfficeAddress } from "../common/Constants";
-import { ErrorPath } from "../common/ErrorUtility";
 import { GetQueryParam } from "../common/Routing";
 import { GetReturnSummaryValues } from "../data/TaxReturnMapper";
 import { GetTransientTaxReturn } from "../services/ApiService";

--- a/src/pages/ErrorPage.jsx
+++ b/src/pages/ErrorPage.jsx
@@ -1,17 +1,10 @@
-import { GetError } from "../common/ErrorUtility";
-import { GetQueryParam } from "../common/Routing";
 import React from "react";
 
-const ErrorPage = ({ match = {} }) => {
-  const errorType = GetQueryParam(match, "errorType");
-  const { heading, message } = GetError(errorType);
-
-  return (
-    <div className="tt_error_container">
-      <h2>{heading}</h2>
-      <p>{message}</p>
-    </div>
-  );
-};
+const ErrorPage = ({ heading, message }) => (
+  <div className="tt_error_container">
+    <h2>{heading}</h2>
+    <p>{message}</p>
+  </div>
+);
 
 export default ErrorPage;

--- a/src/pages/ErrorPage.jsx
+++ b/src/pages/ErrorPage.jsx
@@ -1,23 +1,17 @@
+import { GetError } from "../common/ErrorUtility";
+import { GetQueryParam } from "../common/Routing";
 import React from "react";
 
-const ErrorPage = props => {
-  const { errorType = 0 } = props.match.params;
+const ErrorPage = ({ match = {} }) => {
+  const errorType = GetQueryParam(match, "errorType");
+  const { heading, message } = GetError(errorType);
 
-  const getErrorMessage = errorType => {
-    switch (errorType) {
-      case "invalidconfirmation": {
-        return "This is an incorrect confirmation number";
-      }
-      case "network": {
-        return "The server is not responding please contact magic people for assistance";
-      }
-      default: {
-        return "Something went wrong";
-      }
-    }
-  };
-
-  return <p>{getErrorMessage(errorType)}</p>;
+  return (
+    <div className="tt_error_container">
+      <h2>{heading}</h2>
+      <p>{message}</p>
+    </div>
+  );
 };
 
 export default ErrorPage;

--- a/src/services/ApiService.js
+++ b/src/services/ApiService.js
@@ -1,12 +1,23 @@
-import axios from "axios";
 import {
-  MapTaxReturnToServerModel,
-  MapResponseDataForTaxReturn
+  MapResponseDataForTaxReturn,
+  MapTaxReturnToServerModel
 } from "../data/TaxReturnMapper";
+
 import { Config } from "@baltimorecounty/javascript-utilities";
+import axios from "axios";
+
 const { getValue } = Config;
 
 let exemptionId = 0;
+
+/**
+ * Determines if api is up or not
+ * @returns true if the api is available
+ */
+const GetStatus = () =>
+  axios
+    .get(`${getValue("apiRoot")}/status`)
+    .then(({ status }) => status === 200);
 
 /**
  * Get a lookup value for a given endpoint
@@ -88,5 +99,6 @@ export {
   GetFilingTypes,
   SaveExemption,
   VerifyAddress,
+  GetStatus,
   SaveReturn
 };


### PR DESCRIPTION
Addresses #102 

- Added check to the app to verify the api is up, if it's not, then we will redirect them to an error page, because they won't be able to submit a form or check their confirmation number.
- Refactored some of the repeated logic mainly found in the error page

I tried to put this network check in app.js and couldn't get it to work, so for the sake of the time, I'm pushing this through with the repeated code, it is probably something we should come back to, and see if we can handle this in one place.