### PR TITLE
Removed bad variable passed to function

### DIFF
--- a/src/common/Caculations.test.js
+++ b/src/common/Caculations.test.js
@@ -45,7 +45,13 @@ describe("Get Calculated Totals", () => {
       transientPenalty,
       totalInterestAndPenalties,
       monthlyTaxRemitted
-    } = GetCalculatedTotals(fields, 0, 0.095, 0.01, 0.1);
+    } = GetCalculatedTotals({
+      fields,
+      monthsLate: 0,
+      taxRate: 0.095,
+      interestRate: 0.01,
+      penaltyRate: 0.1
+    });
 
     expect(totalExemptions).toEqual(0);
     expect(netRoomRentalCollections).toEqual(100);
@@ -71,7 +77,13 @@ describe("Get Calculated Totals", () => {
       transientPenalty,
       totalInterestAndPenalties,
       monthlyTaxRemitted
-    } = GetCalculatedTotals(fields, 8, 0.095, 0.01, 0.1);
+    } = GetCalculatedTotals({
+      fields,
+      monthsLate: 8,
+      taxRate: 0.095,
+      interestRate: 0.01,
+      penaltyRate: 0.1
+    });
 
     expect(totalExemptions).toEqual(0);
     expect(netRoomRentalCollections).toEqual(100);
@@ -97,7 +109,13 @@ describe("Get Calculated Totals", () => {
       transientPenalty,
       totalInterestAndPenalties,
       monthlyTaxRemitted
-    } = GetCalculatedTotals(fields, 0, 0.095, 0.01, 0.1);
+    } = GetCalculatedTotals({
+      fields,
+      monthsLate: 0,
+      taxRate: 0.095,
+      interestRate: 0.01,
+      penaltyRate: 0.1
+    });
 
     expect(totalExemptions).toEqual(-20);
     expect(netRoomRentalCollections).toEqual(100);
@@ -123,7 +141,13 @@ describe("Get Calculated Totals", () => {
       transientPenalty,
       totalInterestAndPenalties,
       monthlyTaxRemitted
-    } = GetCalculatedTotals(fields, 8, 0.095, 0.01, 0.1);
+    } = GetCalculatedTotals({
+      fields,
+      monthsLate: 8,
+      taxRate: 0.095,
+      interestRate: 0.01,
+      penaltyRate: 0.1
+    });
 
     expect(totalExemptions).toEqual(-20);
     expect(netRoomRentalCollections).toEqual(100);

--- a/src/common/Calculations.js
+++ b/src/common/Calculations.js
@@ -40,13 +40,13 @@ const CalculateTaxCollected = (
  * @param {number} penaltyRate rate as decimal
  * @returns {object} an object containing all the desired totals
  */
-const GetCalculatedTotals = (
+const GetCalculatedTotals = ({
   fields = {},
   monthsLate = 0,
   taxRate = RatesAndFees.TransientTaxRate,
   interestRate = RatesAndFees.InterestRate,
   penaltyRate = RatesAndFees.PenaltyRate
-) => {
+}) => {
   const {
     grossRentalCollected,
     nonTransientRentalCollected,

--- a/src/components/forms/MonthlyPaymentForm.jsx
+++ b/src/components/forms/MonthlyPaymentForm.jsx
@@ -72,14 +72,14 @@ const MonthlyPaymentForm = props => {
           transientPenalty,
           totalInterestAndPenalties,
           monthlyTaxRemitted
-        } = GetCalculatedTotals(
-          {
+        } = GetCalculatedTotals({
+          fields: {
             grossRentalCollected,
             nonTransientRentalCollected,
             governmentExemptRentalCollected
           },
           monthsLate
-        );
+        });
 
         return (
           <Form>

--- a/src/components/forms/MonthlyPaymentForm.jsx
+++ b/src/components/forms/MonthlyPaymentForm.jsx
@@ -24,7 +24,7 @@ const MonthlyPaymentForm = props => {
 
   const month = date.getMonth() + 1;
   const year = date.getFullYear();
-  const { returnStatus: { isLate, value: monthsLate = 0 } = {} } =
+  const { returnStatus: { value: monthsLate = 0 } = {} } =
     formik.values.monthsToReport || {};
 
   const existingValues = getExistingValues(
@@ -78,8 +78,7 @@ const MonthlyPaymentForm = props => {
             nonTransientRentalCollected,
             governmentExemptRentalCollected
           },
-          monthsLate,
-          isLate
+          monthsLate
         );
 
         return (


### PR DESCRIPTION
Resolves bug where `isLate` was being passed as the Transient Tax Rate instead of using the default value for Tax Rate, causing the `Net Room Rentals` to be equal to the `Tax Collected`, which is wrong. It should be `Net Room Rentals * the Tax Rate`

![image](https://user-images.githubusercontent.com/1933400/71844810-03c93600-3095-11ea-9a5e-808a7fc8836a.png)


Refactored GetCalculatedTotals to take an single object param instead of multiple params. This helps us avoid setting a ~~variable~~ param by accident, like what happened when `taxRate` was set to `isLate` on the monthly payment form.