### PR TITLE
Fix Bad Calculation for Tax Remitted

### DIFF
--- a/src/data/TaxReturnMapper.js
+++ b/src/data/TaxReturnMapper.js
@@ -154,7 +154,11 @@ const MapResponseDataForTaxReturn = taxReturn => {
 
   const netRoomRentals = SumTotals([occupancyTaxCollected, exemptions]);
 
-  const taxCollected = netRoomRentals.map(CalculateTaxCollected);
+  console.log(netRoomRentals);
+
+  const taxCollected = netRoomRentals.map(netRoomRental =>
+    CalculateTaxCollected(netRoomRental)
+  );
 
   const interestCollected = taxCollected.map(tax =>
     isLate ? CalculateInterest(tax, monthsLate) : 0

--- a/src/data/TaxReturnMapper.js
+++ b/src/data/TaxReturnMapper.js
@@ -154,8 +154,6 @@ const MapResponseDataForTaxReturn = taxReturn => {
 
   const netRoomRentals = SumTotals([occupancyTaxCollected, exemptions]);
 
-  console.log(netRoomRentals);
-
   const taxCollected = netRoomRentals.map(netRoomRental =>
     CalculateTaxCollected(netRoomRental)
   );


### PR DESCRIPTION
Since the CalculateTaxCollected changed to be able to be passed a tax rate, the CalculateTaxCollected can no longer be passed directly to the mapping function. Changed to just past the currency total