### PR TITLE
Fix Positive Number Exemption

### DIFF
--- a/src/data/TaxReturnMapper.js
+++ b/src/data/TaxReturnMapper.js
@@ -124,6 +124,12 @@ const GetReturnSummaryValues = taxReturnValues => {
 };
 
 /**
+ * Return the negative for a given number, positive or negative
+ * @param {number} num
+ */
+const toNegativeValue = num => Math.abs(num) * -1;
+
+/**
  * Maps Transient Tax Form Data to the confirmation page
  * @param {object} taxReturn tax return form data model
  */
@@ -154,7 +160,7 @@ const MapResponseDataForTaxReturn = taxReturn => {
   const exemptions = GetTotalsForMonth(monthlyData, [
     "governmentExemptRentalCollected",
     "nonTransientRentalCollected"
-  ]);
+  ]).map(toNegativeValue);
 
   const netRoomRentals = SumTotals([occupancyTaxCollected, exemptions]);
 

--- a/src/services/ApiService.js
+++ b/src/services/ApiService.js
@@ -49,7 +49,7 @@ const GetTransientTaxReturn = confirmationNumber =>
       )}/transientTax/return?confirmationnumber=${confirmationNumber}`
     )
     .then(({ status, data }) =>
-      status === 200 ? MapResponseDataForTaxReturn(data) : []
+      status === 200 ? MapResponseDataForTaxReturn(data, true) : []
     );
 
 /**

--- a/src/services/ApiService.js
+++ b/src/services/ApiService.js
@@ -49,7 +49,7 @@ const GetTransientTaxReturn = confirmationNumber =>
       )}/transientTax/return?confirmationnumber=${confirmationNumber}`
     )
     .then(({ status, data }) =>
-      status === 200 ? MapResponseDataForTaxReturn(data, true) : []
+      status === 200 ? MapResponseDataForTaxReturn(data) : []
     );
 
 /**


### PR DESCRIPTION
The confirmation page was displaying exemptions as a positive number because that is what the api was returning. 

This fix that when mapping values, the exemptions will always be negative.