### PR TITLE
Remove date min max

### DIFF
--- a/src/common/ExemptionUtilities.js
+++ b/src/common/ExemptionUtilities.js
@@ -21,6 +21,15 @@ const GetExemptionFormErrors = exemption => {
     activeFormErrors.push({ key: "toDate", error: "To Date Required" });
   }
 
+  if (fromDate && toDate) {
+    if (parseInt(fromDate.getTime()) > parseInt(toDate.getTime())) {
+      activeFormErrors.push({
+        key: "badDateRange",
+        error: "To Date must come after from date"
+      });
+    }
+  }
+
   return activeFormErrors;
 };
 

--- a/src/components/formik/DateRangeSelector.jsx
+++ b/src/components/formik/DateRangeSelector.jsx
@@ -8,8 +8,7 @@ const DateRangeSelector = props => {
     toDate: toDateFromProps,
     handleChange = () => {},
     onClick = () => {},
-    minDate = new Date(),
-    maxDate = new Date()
+    minDate = new Date()
   } = props;
   const [fromDate, setFromDate] = useState(fromDateFromProps);
   const [toDate, setToDate] = useState(toDateFromProps);
@@ -50,8 +49,6 @@ const DateRangeSelector = props => {
           selected={fromDate}
           onChange={handleFromDateChange}
           onClickOutside={() => onClick(null, fromDateId)}
-          minDate={minDate}
-          maxDate={maxDate}
           selectsStart
           startDate={minDate}
           value={fromDate}
@@ -64,8 +61,6 @@ const DateRangeSelector = props => {
           name={toDateId}
           selected={toDate}
           onChange={handleToDateChange}
-          minDate={minDate}
-          maxDate={maxDate}
           selectsEnd
           startDate={fromDate}
           onClickOutside={() => onClick(null, toDateId)}

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -131,11 +131,13 @@ const ExemptionSelector = props => {
       {(touched.fromDate || touched.toDate) &&
         formErrors.some(
           ({ key }) => key === "toDate" || key === "fromDate"
-        ) && <BasicErrorMessage message="To Date and From Date are Required" />}
+        ) && (
+          <BasicErrorMessage message="To and From Date are required to submit an exemption." />
+        )}
       {touched.fromDate &&
         touched.toDate &&
         formErrors.some(({ key }) => key === "badDateRange") && (
-          <BasicErrorMessage message="To Date must come after From Date" />
+          <BasicErrorMessage message="To Date must come after From Date." />
         )}
       <button onClick={saveExemption} type="button">
         {exemption.id ? "Update" : "Add"}

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -129,14 +129,14 @@ const ExemptionSelector = props => {
         onClick={handleFieldClick}
       />
       {(touched.fromDate || touched.toDate) &&
-        formErrors.map(item => {
-          return item.key === "fromDate" ||
-            item.key === "toDate" ||
-            item.key === "badDateRange" ? (
-            <BasicErrorMessage message={item.error} />
-          ) : null;
-        })}
-
+        formErrors.some(
+          ({ key }) => key === "toDate" || key === "fromDate"
+        ) && <BasicErrorMessage message="To Date and From Date are Required" />}
+      {touched.fromDate &&
+        touched.toDate &&
+        formErrors.some(({ key }) => key === "badDateRange") && (
+          <BasicErrorMessage message="To Date must come after From Date" />
+        )}
       <button onClick={saveExemption} type="button">
         {exemption.id ? "Update" : "Add"}
       </button>

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -1,7 +1,3 @@
-import {
-  GetMaxExemptionEndDate,
-  GetMinExemptionStartDate
-} from "../../common/DatesUtilities";
 import React, { useEffect, useState } from "react";
 
 import BasicErrorMessage from "../BasicErrorMessage";
@@ -15,8 +11,7 @@ import { RadioButton } from "../../common/RadioButton";
 const ExemptionSelector = props => {
   const {
     exemption: exemptionFromProps = {},
-    onExemptionSave = () => {},
-    monthlyData = []
+    onExemptionSave = () => {}
   } = props;
   const [isLoading, setIsLoading] = useState(true);
   const [exemptionTypes, setExemptionTypes] = useState([]);
@@ -26,8 +21,6 @@ const ExemptionSelector = props => {
     GetExemptionFormErrors(exemptionFromProps)
   );
   const [exemption, setExemption] = useState(exemptionFromProps);
-  const minDate = GetMinExemptionStartDate(monthlyData);
-  const maxDate = GetMaxExemptionEndDate(monthlyData);
 
   useEffect(() => {
     if (exemptionTypes.length === 0) {
@@ -134,15 +127,16 @@ const ExemptionSelector = props => {
         toDate={exemption.toDate}
         handleChange={handleExemptionDateChange}
         onClick={handleFieldClick}
-        minDate={minDate}
-        maxDate={maxDate}
       />
       {(touched.fromDate || touched.toDate) &&
-        formErrors.some(
-          ({ key }) => key === "fromDate" || key === "toDate"
-        ) && (
-          <BasicErrorMessage message="To and From Date are required to submit an exemption." />
-        )}
+        formErrors.map(item => {
+          return item.key === "fromDate" ||
+            item.key === "toDate" ||
+            item.key === "badDateRange" ? (
+            <BasicErrorMessage message={item.error} />
+          ) : null;
+        })}
+
       <button onClick={saveExemption} type="button">
         {exemption.id ? "Update" : "Add"}
       </button>


### PR DESCRIPTION
This PR is to remove forcing users to match exemption dates with monthly dates per user request. 

With that being removed this introduced the bug of bad date ranges where the To date could come before the From date. In order to handle that we now do a check specific for those dates (converting dates to time and comparing) and then flagging the fields with an error if they dont work.