### PR TITLE
reverted logic changes to account for no date restrictuions

### DIFF
--- a/src/components/formik/DateRangeSelector.jsx
+++ b/src/components/formik/DateRangeSelector.jsx
@@ -1,15 +1,14 @@
 import React, { useEffect, useState } from "react";
 
 import DatePicker from "react-datepicker";
+import { addDays } from "date-fns";
 
 const DateRangeSelector = props => {
   const {
     fromDate: fromDateFromProps,
     toDate: toDateFromProps,
     handleChange = () => {},
-    onClick = () => {},
-    minDate = new Date(),
-    maxDate = new Date()
+    onClick = () => {}
   } = props;
   const [fromDate, setFromDate] = useState(fromDateFromProps);
   const [toDate, setToDate] = useState(toDateFromProps);
@@ -50,10 +49,8 @@ const DateRangeSelector = props => {
           selected={fromDate}
           onChange={handleFromDateChange}
           onClickOutside={() => onClick(null, fromDateId)}
-          minDate={minDate}
-          maxDate={maxDate}
+          maxDate={addDays(toDate, -1)}
           selectsStart
-          startDate={minDate}
           value={fromDate}
         />
       </div>
@@ -64,8 +61,7 @@ const DateRangeSelector = props => {
           name={toDateId}
           selected={toDate}
           onChange={handleToDateChange}
-          minDate={minDate}
-          maxDate={maxDate}
+          minDate={addDays(fromDate, 1)}
           selectsEnd
           startDate={fromDate}
           onClickOutside={() => onClick(null, toDateId)}

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -1,7 +1,3 @@
-import {
-  GetMaxExemptionEndDate,
-  GetMinExemptionStartDate
-} from "../../common/DatesUtilities";
 import React, { useEffect, useState } from "react";
 
 import BasicErrorMessage from "../BasicErrorMessage";
@@ -15,8 +11,7 @@ import { RadioButton } from "../../common/RadioButton";
 const ExemptionSelector = props => {
   const {
     exemption: exemptionFromProps = {},
-    onExemptionSave = () => {},
-    monthlyData = []
+    onExemptionSave = () => {}
   } = props;
   const [isLoading, setIsLoading] = useState(true);
   const [exemptionTypes, setExemptionTypes] = useState([]);
@@ -26,8 +21,6 @@ const ExemptionSelector = props => {
     GetExemptionFormErrors(exemptionFromProps)
   );
   const [exemption, setExemption] = useState(exemptionFromProps);
-  const minDate = GetMinExemptionStartDate(monthlyData);
-  const maxDate = GetMaxExemptionEndDate(monthlyData);
 
   useEffect(() => {
     if (exemptionTypes.length === 0) {
@@ -134,8 +127,6 @@ const ExemptionSelector = props => {
         toDate={exemption.toDate}
         handleChange={handleExemptionDateChange}
         onClick={handleFieldClick}
-        minDate={minDate}
-        maxDate={maxDate}
       />
       {(touched.fromDate || touched.toDate) &&
         formErrors.some(


### PR DESCRIPTION
This is a more simplified way (rollback) to keep from limiting user on exemption dates. No custom error message for bad date range but also less code changes and less chance to introduce new bugs. 