### PR TITLE
Add Unique Id For Confirmation

### DIFF
--- a/src/components/forms/ReviewFormPanel.jsx
+++ b/src/components/forms/ReviewFormPanel.jsx
@@ -16,10 +16,22 @@ const ReviewFormPanel = props => {
     paymentInterval
   } = values.monthsToReport;
 
+  /** Helper to generate a unique id for confirmation number */
+  const generateConfirmationNumberId = () => {
+    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
+      (
+        c ^
+        (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+      ).toString(16)
+    );
+  };
+
   const handleSubmit = () => {
     setIsSubmitting(true);
     SaveReturn(values).then(({ ConfirmationNumber = 0 }) => {
-      history.push(`/confirmation/${ConfirmationNumber}`);
+      history.push(
+        `/confirmation/${generateConfirmationNumberId()}-${ConfirmationNumber}`
+      );
     });
   };
 

--- a/src/pages/ConfirmationPage.jsx
+++ b/src/pages/ConfirmationPage.jsx
@@ -34,6 +34,10 @@ const ConfirmationForm = ({ match = {} }) => {
     ? format(new Date(dateSubmitted), "MMMM dd, yyyy")
     : "";
 
+  const confirmationNumberToDisplay = confirmationNumber
+    .split("-")
+    .reverse()[0];
+
   useEffect(() => {
     GetTransientTaxReturn(confirmationNumber)
       .then(response => {
@@ -59,11 +63,11 @@ const ConfirmationForm = ({ match = {} }) => {
             <span>Your Baltimore County Transient Occupancy Tax Return</span>
           </h1>
           <h2>Transient Tax Return Submitted</h2>
-          <h3>Confirmation Number: {confirmationNumber}</h3>
+          <h3>Confirmation Number: {confirmationNumberToDisplay}</h3>
           <p>
             You have successfully completed the Baltimore County Transient
             Occupancy Tax Return. Your confirmation number for this return is{" "}
-            <strong>{confirmationNumber}</strong>.
+            <strong>{confirmationNumberToDisplay}</strong>.
           </p>
           <p>
             Please present this number to the appropriate Budget and Finance


### PR DESCRIPTION
Fake a value for a unique id so that a user doesn't realize they could just change the number to look at other returns.

This is dependent on a service change, and does not impact teh original way confirmation numbers work. Aka you can still put in `/confirmation/{confirmtionNumber}`