### PR TITLE
Sum Totals After They are calculated

### DIFF
--- a/src/common/Calculations.js
+++ b/src/common/Calculations.js
@@ -1,5 +1,7 @@
 import { RatesAndFees } from "./Constants";
 
+const roundCurrency = value => Math.round(value * 100) / 100;
+
 /**
  * Calculate the interest based on tax collected and the number of months late.
  * @param {number} taxCollected dollar amount to base the interest off
@@ -10,7 +12,7 @@ const CalculateInterest = (
   taxCollected,
   numberOfMonthsLate,
   interestRate = RatesAndFees.InterestRate
-) => taxCollected * numberOfMonthsLate * interestRate;
+) => roundCurrency(taxCollected * numberOfMonthsLate * interestRate);
 
 /**
  * Calculate the penalty fee based on tax collected.
@@ -20,7 +22,7 @@ const CalculateInterest = (
 const CalculatePenalty = (
   taxCollected,
   penaltyRate = RatesAndFees.PenaltyRate
-) => taxCollected * penaltyRate;
+) => roundCurrency(taxCollected * penaltyRate);
 
 /**
  * Calculate tax collected based on net Room Rental Collections and the current Transient Tax Rate
@@ -29,7 +31,7 @@ const CalculatePenalty = (
 const CalculateTaxCollected = (
   netRoomRentalCollections,
   taxRate = RatesAndFees.TransientTaxRate
-) => netRoomRentalCollections * taxRate;
+) => roundCurrency(netRoomRentalCollections * taxRate);
 
 /**
  * Get a list of calculations based on given Transient Tax Data
@@ -126,9 +128,7 @@ const SumTotals = (totals = []) => {
   );
   const result = Array.from({ length: maxNumberOfItems });
   return result.map((_, i) =>
-    totals
-      .map(xs => xs[i] || 0)
-      .reduce((sum, x) => sum + Math.round(x * 100) / 100, 0)
+    totals.map(xs => xs[i] || 0).reduce((sum, x) => sum + roundCurrency(x), 0)
   );
 };
 

--- a/src/common/Calculations.js
+++ b/src/common/Calculations.js
@@ -90,8 +90,6 @@ const GetCalculatedTotals = ({
   };
 };
 
-const sumReducer = (accumulator, currentValue) => accumulator + currentValue;
-
 /**
  * Get totals for a month for any number of fields available in the monthly data object
  * @param {array} monthlyData list of objects that contain monthly data
@@ -105,12 +103,6 @@ const GetTotalsForMonth = (monthlyData = [], keys = []) => {
     });
     return sum;
   });
-  const shouldAddTotal = monthlyData.length === 3;
-
-  if (shouldAddTotal) {
-    monthlyTotals.push(monthlyTotals.reduce(sumReducer));
-  }
-
   return monthlyTotals;
 };
 

--- a/src/data/TaxReturnMapper.js
+++ b/src/data/TaxReturnMapper.js
@@ -128,6 +128,7 @@ const GetReturnSummaryValues = taxReturnValues => {
  * @param {number} num
  */
 const toNegativeValue = num => Math.abs(num) * -1;
+const sumReducer = (accumulator, currentValue) => accumulator + currentValue;
 
 /**
  * Maps Transient Tax Form Data to the confirmation page
@@ -145,7 +146,6 @@ const MapResponseDataForTaxReturn = taxReturn => {
     isLate,
     monthsLate
   } = getDateInformation(taxReturn);
-
   /** Get Formatted Date Submitted */
   formattedResponse.DateSubmitted = dateSubmitted;
 
@@ -175,6 +175,17 @@ const MapResponseDataForTaxReturn = taxReturn => {
   const penaltiesCollected = taxCollected.map(tax =>
     isLate ? CalculatePenalty(tax) : 0
   );
+
+  const shouldAddTotal = monthlyData.length === 3;
+
+  if (shouldAddTotal) {
+    occupancyTaxCollected.push(occupancyTaxCollected.reduce(sumReducer, 0));
+    exemptions.push(exemptions.reduce(sumReducer, 0));
+    taxCollected.push(taxCollected.reduce(sumReducer, 0));
+    netRoomRentals.push(netRoomRentals.reduce(sumReducer, 0));
+    interestCollected.push(interestCollected.reduce(sumReducer, 0));
+    penaltiesCollected.push(penaltiesCollected.reduce(sumReducer, 0));
+  }
 
   const taxRemitted = SumTotals([
     taxCollected,


### PR DESCRIPTION
Resolves #229 

Total Values were being run through calculation functions after the individual months had already been calculated. 

We only want to run the calculations on the individual months, and then add the calculated values.  This ensures the numbers match up and avoids the scenario in #229.