### PR TITLE
fix exemption message for Non-Transient

### DIFF
--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -6,7 +6,7 @@ const DateTypes = {
 };
 
 const FormHints = {
-  NonTransient: "Sleeping accommodations from 90 consecutive days"
+  NonTransient: "Sleeping accommodations for 90 consecutive days"
 };
 
 const PaymentDirections = {

--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -105,7 +105,7 @@ const GetMaxExemptionEndDate = (monthlyData = []) => {
   return endOfMonth(new Date(year, month - 1, 1));
 };
 const IsDateInRange = (fromDate, toDate) =>
-  differenceInDays(toDate, fromDate) >= 90 ? true : false;
+  differenceInDays(toDate, fromDate) >= 90;
 
 export {
   DefaultDateFormat,

--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -104,6 +104,22 @@ const GetMaxExemptionEndDate = (monthlyData = []) => {
   const { month, year } = monthlyData.filter(hasExemption).pop();
   return endOfMonth(new Date(year, month - 1, 1));
 };
+const isDateInRange = (fromDate, toDate) => {
+  var one_day = 1000 * 60 * 60 * 24;
+
+  // Convert both dates to milliseconds
+  var date1_ms = fromDate.getTime();
+  var date2_ms = toDate.getTime();
+
+  // Calculate the difference in milliseconds
+  var difference_ms = date2_ms - date1_ms;
+
+  // Convert back to days and return
+  let totalDays = Math.round(difference_ms / one_day);
+
+  let isDaysValid = totalDays >= 90 ? true : false;
+  return isDaysValid;
+};
 
 export {
   DefaultDateFormat,
@@ -112,5 +128,6 @@ export {
   GetDueDateStatus,
   GetFormatedDateTime,
   GetMinExemptionStartDate,
-  GetMaxExemptionEndDate
+  GetMaxExemptionEndDate,
+  isDateInRange
 };

--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -104,7 +104,7 @@ const GetMaxExemptionEndDate = (monthlyData = []) => {
   const { month, year } = monthlyData.filter(hasExemption).pop();
   return endOfMonth(new Date(year, month - 1, 1));
 };
-const IsDateInRange = (fromDate, toDate) =>
+const IsDateRangeAtLeast90Days = (fromDate, toDate) =>
   differenceInDays(toDate, fromDate) >= 90;
 
 export {
@@ -115,5 +115,5 @@ export {
   GetFormatedDateTime,
   GetMinExemptionStartDate,
   GetMaxExemptionEndDate,
-  IsDateInRange
+  IsDateRangeAtLeast90Days
 };

--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -104,22 +104,8 @@ const GetMaxExemptionEndDate = (monthlyData = []) => {
   const { month, year } = monthlyData.filter(hasExemption).pop();
   return endOfMonth(new Date(year, month - 1, 1));
 };
-const isDateInRange = (fromDate, toDate) => {
-  var one_day = 1000 * 60 * 60 * 24;
-
-  // Convert both dates to milliseconds
-  var date1_ms = fromDate.getTime();
-  var date2_ms = toDate.getTime();
-
-  // Calculate the difference in milliseconds
-  var difference_ms = date2_ms - date1_ms;
-
-  // Convert back to days and return
-  let totalDays = Math.round(difference_ms / one_day);
-
-  let isDaysValid = totalDays >= 90 ? true : false;
-  return isDaysValid;
-};
+const IsDateInRange = (fromDate, toDate) =>
+  differenceInDays(toDate, fromDate) >= 90 ? true : false;
 
 export {
   DefaultDateFormat,
@@ -129,5 +115,5 @@ export {
   GetFormatedDateTime,
   GetMinExemptionStartDate,
   GetMaxExemptionEndDate,
-  isDateInRange
+  IsDateInRange
 };

--- a/src/common/DatesUtilities.test.js
+++ b/src/common/DatesUtilities.test.js
@@ -3,7 +3,7 @@ import {
   GetFormattedDueDate,
   GetMaxExemptionEndDate,
   GetMinExemptionStartDate,
-  isDateInRange
+  IsDateRangeAtLeast90Days
 } from "./DatesUtilities";
 
 describe("Get Formatted Due Date", () => {
@@ -161,14 +161,14 @@ describe("Get Max Date", () => {
   });
 });
 
-describe("isDateInRange", () => {
+describe("IsDateRangeAtLeast90Days", () => {
   test("should return true if the difference in days for the to and from date is greater than 90 days", () => {
-    const actual = isDateInRange(new Date(2020, 0, 1), new Date(2020, 5, 1)); // Jan 1 to June 1
+    const actual = IsDateRangeAtLeast90Days(new Date(2020, 0, 1), new Date(2020, 5, 1)); // Jan 1 to June 1
     expect(actual).toEqual(true);
   });
 
   test("should return false if the difference in days for the to and from date is less than 90 days", () => {
-    const actual = isDateInRange(new Date(2020, 0, 1), new Date(2020, 1, 1)); // Jan 1 to Feb 1
+    const actual = IsDateRangeAtLeast90Days(new Date(2020, 0, 1), new Date(2020, 1, 1)); // Jan 1 to Feb 1
     expect(actual).toEqual(false);
   });
 });

--- a/src/common/ExemptionUtilities.js
+++ b/src/common/ExemptionUtilities.js
@@ -4,7 +4,7 @@
  */
 const GetExemptionFormErrors = exemption => {
   const activeFormErrors = [];
-  const { fromDate, toDate, type, isDaysValid } = exemption;
+  const { fromDate, toDate, type, isDateRangeAtLeast90days } = exemption;
 
   if (!type) {
     activeFormErrors.push({
@@ -21,9 +21,9 @@ const GetExemptionFormErrors = exemption => {
     activeFormErrors.push({ key: "toDate", error: "To Date Required" });
   }
 
-  if (type === 1 && fromDate && toDate && !isDaysValid) {
+  if (type === 1 && fromDate && toDate && !isDateRangeAtLeast90days) {
     activeFormErrors.push({
-      key: "isDaysValid",
+      key: "isDateRangeAtLeast90days",
       error: "Data range must be at least 90 consecutive days"
     });
   }

--- a/src/common/ExemptionUtilities.js
+++ b/src/common/ExemptionUtilities.js
@@ -4,7 +4,7 @@
  */
 const GetExemptionFormErrors = exemption => {
   const activeFormErrors = [];
-  const { fromDate, toDate, type } = exemption;
+  const { fromDate, toDate, type, isDaysValid } = exemption;
 
   if (!type) {
     activeFormErrors.push({
@@ -19,6 +19,13 @@ const GetExemptionFormErrors = exemption => {
 
   if (!toDate) {
     activeFormErrors.push({ key: "toDate", error: "To Date Required" });
+  }
+
+  if (type === 1 && fromDate && toDate && !isDaysValid) {
+    activeFormErrors.push({
+      key: "isDaysValid",
+      error: "Data range must be at least 90 consecutive days"
+    });
   }
 
   return activeFormErrors;

--- a/src/components/ExemptionListItem.jsx
+++ b/src/components/ExemptionListItem.jsx
@@ -9,7 +9,14 @@ const ExemptionListItem = props => {
     handleRemoveClick,
     isSelectorFormDirty
   } = props;
-  const { id, type, label, fromDate, toDate, isDaysValid } = exemption;
+  const {
+    id,
+    type,
+    label,
+    fromDate,
+    toDate,
+    isDateRangeAtLeast90days
+  } = exemption;
 
   const editItem = () => {
     handleEditClick({
@@ -18,7 +25,7 @@ const ExemptionListItem = props => {
       label,
       fromDate,
       toDate,
-      isDaysValid
+      isDateRangeAtLeast90days
     });
   };
 

--- a/src/components/ExemptionListItem.jsx
+++ b/src/components/ExemptionListItem.jsx
@@ -9,7 +9,7 @@ const ExemptionListItem = props => {
     handleRemoveClick,
     isSelectorFormDirty
   } = props;
-  const { id, type, label, fromDate, toDate } = exemption;
+  const { id, type, label, fromDate, toDate, isDaysValid } = exemption;
 
   const editItem = () => {
     handleEditClick({
@@ -17,7 +17,8 @@ const ExemptionListItem = props => {
       type,
       label,
       fromDate,
-      toDate
+      toDate,
+      isDaysValid
     });
   };
 

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -71,9 +71,9 @@ const ExemptionSelector = props => {
       : false;
 
   const handleExemptionTypeChange = ({ type, label }) => {
-    let { fromDate, toDate } = exemption;
+    const { fromDate, toDate } = exemption;
     setIsFormDirty(true);
-    let isDateRangeAtLeast90days = checkNonTransientDateCondition(
+    const isDateRangeAtLeast90days = checkNonTransientDateCondition(
       type,
       fromDate,
       toDate
@@ -85,17 +85,10 @@ const ExemptionSelector = props => {
   };
 
   const handleExemptionDateChange = ({ fromDate, toDate }) => {
-    let isDateRangeAtLeast90days = true;
-    let type = Object.values(exemption).length > 0 ? exemption.type : undefined;
+    const type = Object.values(exemption).length > 0 ? exemption.type : null;
     setIsFormDirty(true);
-
-    if (type !== undefined) {
-      isDateRangeAtLeast90days = checkNonTransientDateCondition(
-        type,
-        fromDate,
-        toDate
-      );
-    }
+    const isDateRangeAtLeast90days =
+      !type || checkNonTransientDateCondition(type, fromDate, toDate);
     setExemption({
       ...exemption,
       ...{ fromDate, toDate, isDateRangeAtLeast90days }

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -7,7 +7,7 @@ import { FormHints } from "../../common/Constants";
 import { GetExemptionFormErrors } from "../../common/ExemptionUtilities";
 import { GetExemptionTypes } from "../../services/ApiService";
 import { RadioButton } from "../../common/RadioButton";
-import { IsDateInRange } from "../../common/DatesUtilities";
+import { IsDateRangeAtLeast90Days } from "../../common/DatesUtilities";
 
 const ExemptionSelector = props => {
   const {
@@ -67,7 +67,7 @@ const ExemptionSelector = props => {
 
   const checkNonTransientDateCondition = (type, fromDate, toDate) =>
     type === nonTransientExemptionType.Id && fromDate && toDate
-      ? IsDateInRange(fromDate, toDate)
+      ? IsDateRangeAtLeast90Days(fromDate, toDate)
       : false;
 
   const handleExemptionTypeChange = ({ type, label }) => {

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -7,7 +7,7 @@ import { FormHints } from "../../common/Constants";
 import { GetExemptionFormErrors } from "../../common/ExemptionUtilities";
 import { GetExemptionTypes } from "../../services/ApiService";
 import { RadioButton } from "../../common/RadioButton";
-import { isDateInRange } from "../../common/DatesUtilities";
+import { IsDateInRange } from "../../common/DatesUtilities";
 
 const ExemptionSelector = props => {
   const {
@@ -63,36 +63,38 @@ const ExemptionSelector = props => {
     }
   };
 
-  const checkNonTransientDateCondition = (type, fromDate, toDate) => {
-    let isDaysValid = false;
-    isDaysValid =
-      type === 1 && fromDate && toDate
-        ? isDateInRange(fromDate, toDate)
-        : false;
-    return isDaysValid;
-  };
+  const checkNonTransientDateCondition = (type, fromDate, toDate) =>
+    type === 1 && fromDate && toDate ? IsDateInRange(fromDate, toDate) : false;
 
   const handleExemptionTypeChange = ({ type, label }) => {
     let { fromDate, toDate } = exemption;
     setIsFormDirty(true);
-    let isDaysValid = checkNonTransientDateCondition(type, fromDate, toDate);
+    let isDateRangeAtLeast90days = checkNonTransientDateCondition(
+      type,
+      fromDate,
+      toDate
+    );
     setExemption({
       ...exemption,
-      ...{ type, label, isDaysValid }
+      ...{ type, label, isDateRangeAtLeast90days }
     });
   };
 
   const handleExemptionDateChange = ({ fromDate, toDate }) => {
-    let isDaysValid = true;
+    let isDateRangeAtLeast90days = true;
     let type = Object.values(exemption).length > 0 ? exemption.type : undefined;
     setIsFormDirty(true);
 
     if (type !== undefined) {
-      isDaysValid = checkNonTransientDateCondition(type, fromDate, toDate);
+      isDateRangeAtLeast90days = checkNonTransientDateCondition(
+        type,
+        fromDate,
+        toDate
+      );
     }
     setExemption({
       ...exemption,
-      ...{ fromDate, toDate, isDaysValid }
+      ...{ fromDate, toDate, isDateRangeAtLeast90days }
     });
   };
 
@@ -155,7 +157,7 @@ const ExemptionSelector = props => {
           <BasicErrorMessage message="To and From Date are required to submit an exemption." />
         )}
       {(touched.fromDate || touched.toDate) &&
-        formErrors.some(({ key }) => key === "isDaysValid") && (
+        formErrors.some(({ key }) => key === "isDateRangeAtLeast90days") && (
           <BasicErrorMessage message="Data range must be at least 90 consecutive days." />
         )}
       <button onClick={saveExemption} type="button">

--- a/src/components/formik/ExemptionSelector.jsx
+++ b/src/components/formik/ExemptionSelector.jsx
@@ -22,7 +22,9 @@ const ExemptionSelector = props => {
     GetExemptionFormErrors(exemptionFromProps)
   );
   const [exemption, setExemption] = useState(exemptionFromProps);
-
+  const nonTransientExemptionType = exemptionTypes.find(
+    x => x.Description === "Non-Transient"
+  );
   useEffect(() => {
     if (exemptionTypes.length === 0) {
       GetExemptionTypes()
@@ -64,7 +66,9 @@ const ExemptionSelector = props => {
   };
 
   const checkNonTransientDateCondition = (type, fromDate, toDate) =>
-    type === 1 && fromDate && toDate ? IsDateInRange(fromDate, toDate) : false;
+    type === nonTransientExemptionType.Id && fromDate && toDate
+      ? IsDateInRange(fromDate, toDate)
+      : false;
 
   const handleExemptionTypeChange = ({ type, label }) => {
     let { fromDate, toDate } = exemption;


### PR DESCRIPTION
please view the issue 15935 in the system of record.

If Non-Transient is selected, then the ‘From’ and ‘To’ date range must be at least 90 consecutive days regardless of type of return (Monthly/Quarterly) or month range of return (e.g., Jan-Mar 2019), i.e., any 90 day or greater range is acceptable. 
 

Also, the word “from” in the Non-Transient description should be changed to “for”.
