### PR TITLE
bug#16084-apply penalty and interest on net room rental

### DIFF
--- a/src/common/Caculations.test.js
+++ b/src/common/Caculations.test.js
@@ -50,7 +50,8 @@ describe("Get Calculated Totals", () => {
       monthsLate: 0,
       taxRate: 0.095,
       interestRate: 0.01,
-      penaltyRate: 0.1
+      penaltyRate: 0.1,
+      addingOneTimePenalty: true
     });
 
     expect(totalExemptions).toEqual(0);
@@ -82,16 +83,17 @@ describe("Get Calculated Totals", () => {
       monthsLate: 8,
       taxRate: 0.095,
       interestRate: 0.01,
-      penaltyRate: 0.1
+      penaltyRate: 0.1,
+      addingOneTimePenalty: true
     });
 
     expect(totalExemptions).toEqual(0);
     expect(netRoomRentalCollections).toEqual(100);
     expect(transientTaxCollected).toEqual(9.5);
-    expect(transientInterest).toEqual(0.76);
-    expect(transientPenalty).toBeCloseTo(0.95, 5);
-    expect(totalInterestAndPenalties).toEqual(1.71);
-    expect(monthlyTaxRemitted).toEqual(11.21);
+    expect(transientInterest).toEqual(8);
+    expect(transientPenalty).toBeCloseTo(10, 5);
+    expect(totalInterestAndPenalties).toEqual(18);
+    expect(monthlyTaxRemitted).toEqual(27.5);
   });
 
   test("should get the proper totals for a return with with exemptions and paid before past due.", () => {
@@ -114,7 +116,8 @@ describe("Get Calculated Totals", () => {
       monthsLate: 0,
       taxRate: 0.095,
       interestRate: 0.01,
-      penaltyRate: 0.1
+      penaltyRate: 0.1,
+      addingOneTimePenalty: true
     });
 
     expect(totalExemptions).toEqual(-20);
@@ -146,16 +149,17 @@ describe("Get Calculated Totals", () => {
       monthsLate: 8,
       taxRate: 0.095,
       interestRate: 0.01,
-      penaltyRate: 0.1
+      penaltyRate: 0.1,
+      addingOneTimePenalty: true
     });
 
     expect(totalExemptions).toEqual(-20);
     expect(netRoomRentalCollections).toEqual(100);
     expect(transientTaxCollected).toEqual(9.5);
-    expect(transientInterest).toEqual(0.76);
-    expect(transientPenalty).toBeCloseTo(0.95, 5);
-    expect(totalInterestAndPenalties).toEqual(1.71);
-    expect(monthlyTaxRemitted).toEqual(11.21);
+    expect(transientInterest).toEqual(9.6);
+    expect(transientPenalty).toBeCloseTo(12, 5);
+    expect(totalInterestAndPenalties).toEqual(21.6);
+    expect(monthlyTaxRemitted).toEqual(31.1);
   });
 });
 

--- a/src/common/Calculations.js
+++ b/src/common/Calculations.js
@@ -47,7 +47,8 @@ const GetCalculatedTotals = ({
   monthsLate = 0,
   taxRate = RatesAndFees.TransientTaxRate,
   interestRate = RatesAndFees.InterestRate,
-  penaltyRate = RatesAndFees.PenaltyRate
+  penaltyRate = RatesAndFees.PenaltyRate,
+  addingOneTimePenalty
 }) => {
   const {
     grossRentalCollected,
@@ -63,19 +64,16 @@ const GetCalculatedTotals = ({
     taxRate
   );
 
-  let transientInterest = 0;
-  let transientPenalty = 0;
-  let totalInterestAndPenalties = 0;
-
-  if (monthsLate) {
-    transientInterest = CalculateInterest(
-      transientTaxCollected,
-      monthsLate,
-      interestRate
-    );
-    transientPenalty = CalculatePenalty(transientTaxCollected, penaltyRate);
-    totalInterestAndPenalties = transientInterest + transientPenalty;
-  }
+  let transientInterest = monthsLate
+    ? CalculateInterest(grossRentalCollected, monthsLate, interestRate)
+    : 0;
+  let transientPenalty =
+    addingOneTimePenalty && monthsLate >= 2
+      ? CalculatePenalty(grossRentalCollected, penaltyRate)
+      : 0;
+  let totalInterestAndPenalties = monthsLate
+    ? transientInterest + transientPenalty
+    : 0;
 
   const monthlyTaxRemitted = transientTaxCollected + totalInterestAndPenalties;
 

--- a/src/common/DatesUtilities.js
+++ b/src/common/DatesUtilities.js
@@ -104,9 +104,9 @@ const GetMaxExemptionEndDate = (monthlyData = []) => {
   const { month, year } = monthlyData.filter(hasExemption).pop();
   return endOfMonth(new Date(year, month - 1, 1));
 };
- /**
-   * differenceInDays does not account for full days. Exmaple: jan 1 2019 to jan 31 2019 returns 30 days
-   */
+/**
+ * differenceInDays does not account for full days. Exmaple: jan 1 2019 to jan 31 2019 returns 30 days
+ */
 const IsDateRangeAtLeast90Days = (fromDate, toDate) => {
   return differenceInDays(toDate, fromDate) + 1 >= 90;
 };

--- a/src/components/forms/MonthlyPaymentForm.jsx
+++ b/src/components/forms/MonthlyPaymentForm.jsx
@@ -32,7 +32,11 @@ const MonthlyPaymentForm = props => {
     data => data.year === year && data.month === month
   );
   const initialValues = { ...initialValuesFromProps, ...existingValues };
-
+  const { monthlyData } = formik.values;
+  const isMonthly = Object.keys(monthlyData).length === 1;
+  const addingOneTimePenalty = !isMonthly
+    ? !monthlyData[0].grossRentalCollected
+    : true;
   return (
     <Formik
       initialValues={initialValues}
@@ -78,7 +82,8 @@ const MonthlyPaymentForm = props => {
             nonTransientRentalCollected,
             governmentExemptRentalCollected
           },
-          monthsLate: isLate ? monthsLate : 0
+          monthsLate: isLate ? monthsLate : 0,
+          addingOneTimePenalty
         });
 
         return (

--- a/src/data/TaxReturnMapper.js
+++ b/src/data/TaxReturnMapper.js
@@ -1,3 +1,4 @@
+import { RatesAndFees } from "../common/Constants";
 import {
   CalculateInterest,
   CalculatePenalty,
@@ -146,6 +147,7 @@ const MapResponseDataForTaxReturn = taxReturn => {
     isLate,
     monthsLate
   } = getDateInformation(taxReturn);
+  const { penaltyRate } = RatesAndFees.PenaltyRate;
   /** Get Formatted Date Submitted */
   formattedResponse.DateSubmitted = dateSubmitted;
 
@@ -168,12 +170,13 @@ const MapResponseDataForTaxReturn = taxReturn => {
     CalculateTaxCollected(netRoomRental)
   );
 
-  const interestCollected = taxCollected.map(tax =>
-    isLate ? CalculateInterest(tax, monthsLate) : 0
+  const interestCollected = netRoomRentals.map(netRoomRental =>
+    isLate ? CalculateInterest(netRoomRental, monthsLate) : 0
   );
-
-  const penaltiesCollected = taxCollected.map(tax =>
-    isLate ? CalculatePenalty(tax) : 0
+  const penaltiesCollected = netRoomRentals.map((netRoomRental, index) =>
+    isLate && monthsLate >= 2 && index === 0
+      ? CalculatePenalty(netRoomRental, penaltyRate)
+      : 0
   );
 
   const shouldAddTotal = monthlyData.length === 3;

--- a/src/data/TaxReturnMapper.js
+++ b/src/data/TaxReturnMapper.js
@@ -1,4 +1,4 @@
-import { RatesAndFees } from "../common/Constants";
+
 import {
   CalculateInterest,
   CalculatePenalty,
@@ -147,7 +147,7 @@ const MapResponseDataForTaxReturn = taxReturn => {
     isLate,
     monthsLate
   } = getDateInformation(taxReturn);
-  const { penaltyRate } = RatesAndFees.PenaltyRate;
+
   /** Get Formatted Date Submitted */
   formattedResponse.DateSubmitted = dateSubmitted;
 
@@ -175,7 +175,7 @@ const MapResponseDataForTaxReturn = taxReturn => {
   );
   const penaltiesCollected = netRoomRentals.map((netRoomRental, index) =>
     isLate && monthsLate >= 2 && index === 0
-      ? CalculatePenalty(netRoomRental, penaltyRate)
+      ? CalculatePenalty(netRoomRental)
       : 0
   );
 


### PR DESCRIPTION
please view the change description https://oittfs.bcg.ad.bcgov.us/baucollection/Enhancement%20List/_queries/edit/16084/?triage=true

Do not assess the one-time penalty in the calculation logic until the payment is on month 2 of being late.

Examples:
Customer is paying for the month of November 2019. Payment is due by 12/31/2019. The net room rental collections is $1000. Form submitted on 1/15/2020. ONLY the 1% interest charge of $10 should be assessed for a total amount due of $1010.

Customer is paying for the month of November 2019. Payment is due by 12/31/2019. The net room rental collections is $1000. Form submitted on 2/1/2020. The one-time 10% penalty should now be assessed ($100) plus 1% interest for January ($10) plus 1% interest for February ($10) for a total due of $1120.

The same logic would apply for quarterly payments. If the payment is due by January 31 and submitted in Feb, only interest is charged. If it's due January 31 and submitted in March, 2 months interest plus the one-time penalty should be assessed.